### PR TITLE
Add test framework with browser validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,13 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "node src/engine.mjs"
+    "start": "node src/engine.mjs",
+    "test": "node --test"
   },
   "dependencies": {
     "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "puppeteer": "^22.0.0"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -78,6 +78,7 @@
   }
 
   // --- state from server ---
+  const controls = ["fpsCap","mirrorWalls","brightness","gamma","rollPx","strobeHz","strobeDuty","strobeLow","gradPhase"];
   let ws = null, P = null, sceneW=512, sceneH=128;
   try {
     ws = new WebSocket(`ws://${location.host}`);
@@ -109,7 +110,6 @@
   }
 
   // --- UI wiring ---
-  const controls = ["fpsCap","mirrorWalls","brightness","gamma","rollPx","strobeHz","strobeDuty","strobeLow","gradPhase"];
   function initUI(){
     // effect select
     const effect = document.getElementById("effect");

--- a/src/engine.mjs
+++ b/src/engine.mjs
@@ -66,6 +66,7 @@ const server = http.createServer((req, res) => {
   if (u.pathname === "/effects.mjs") return streamFile(path.join(__dirname, "effects.mjs"), "text/javascript", res);
   if (u.pathname === "/layout/left")  return sendJson(layoutLeft, res);
   if (u.pathname === "/layout/right") return sendJson(layoutRight, res);
+  if (u.pathname === "/favicon.ico") return streamFile(path.join(PUBLIC_DIR, "favicon.ico"), "image/x-icon", res);
   // fallback: 404
   res.writeHead(404).end("Not found");
 });

--- a/test/engine.test.mjs
+++ b/test/engine.test.mjs
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'assert/strict';
+import { spawn } from 'child_process';
+import { once } from 'events';
+import { createInterface } from 'readline';
+import { readFile } from 'fs/promises';
+import { fileURLToPath } from 'url';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+async function getFrame(){
+  const proc = spawn('node', ['src/engine.mjs'], { cwd: ROOT });
+  const rl = createInterface({ input: proc.stdout });
+  let jsonLine = null;
+  for await (const line of rl) {
+    if (line.startsWith('{')) { jsonLine = line; break; }
+  }
+  proc.kill();
+  await once(proc, 'exit');
+  return JSON.parse(jsonLine);
+}
+
+function collectSections(layout){
+  const map = {};
+  layout.runs.forEach(run => {
+    run.sections.forEach(sec => { map[sec.id] = sec.led_count; });
+  });
+  return map;
+}
+
+test('emits valid JSON structured output', async () => {
+  const frame = await getFrame();
+  assert.equal(typeof frame.ts, 'number');
+  assert.equal(typeof frame.frame, 'number');
+  assert.equal(typeof frame.fps, 'number');
+  assert.equal(frame.format, 'rgb8');
+  assert.ok(frame.sides.left && frame.sides.right);
+});
+
+test('output matches configuration section lengths', async () => {
+  const frame = await getFrame();
+  const leftCfg = JSON.parse(await readFile(new URL('../config/left.json', import.meta.url)));
+  const rightCfg = JSON.parse(await readFile(new URL('../config/right.json', import.meta.url)));
+  const leftSections = collectSections(leftCfg);
+  const rightSections = collectSections(rightCfg);
+
+  const leftOut = frame.sides[leftCfg.side];
+  const rightOut = frame.sides[rightCfg.side];
+
+  assert.deepEqual(Object.keys(leftOut).sort(), Object.keys(leftSections).sort());
+  assert.deepEqual(Object.keys(rightOut).sort(), Object.keys(rightSections).sort());
+
+  for (const [id, len] of Object.entries(leftSections)) {
+    assert.equal(leftOut[id].length, len);
+  }
+  for (const [id, len] of Object.entries(rightSections)) {
+    assert.equal(rightOut[id].length, len);
+  }
+});

--- a/test/web.test.mjs
+++ b/test/web.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'assert/strict';
+import { spawn } from 'child_process';
+import { once } from 'events';
+import { fileURLToPath } from 'url';
+import puppeteer from 'puppeteer';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+async function waitForServer(url, retries = 100){
+  for (let i = 0; i < retries; i++) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {}
+    await new Promise(r => setTimeout(r, 100));
+  }
+  throw new Error('server not responding');
+}
+
+test('web view loads with no console errors', async () => {
+  const proc = spawn('node', ['src/engine.mjs'], { cwd: ROOT });
+  let browser;
+  try {
+    await waitForServer('http://127.0.0.1:8080');
+
+    browser = await puppeteer.launch({ headless: true, args: ['--no-sandbox'] });
+    const page = await browser.newPage();
+    const errors = [];
+    page.on('pageerror', err => errors.push(err));
+    page.on('console', msg => { if (msg.type() === 'error') errors.push(new Error(msg.text())); });
+
+    await page.goto('http://127.0.0.1:8080', { waitUntil: 'networkidle0' });
+    assert.equal(errors.length, 0);
+  } finally {
+    if (browser) await browser.close().catch(() => {});
+    proc.kill();
+    await once(proc, 'exit').catch(() => {});
+  }
+});


### PR DESCRIPTION
## Summary
- add node-based test runner and puppeteer browser checks
- verify generated JSON frames and layout section lengths
- ensure web UI loads without console errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac6bb4e5bc8322ada82ee55c13fbdd