### PR TITLE
Modularize UI preview into connection, controls, and renderer

### DIFF
--- a/src/server.mjs
+++ b/src/server.mjs
@@ -23,6 +23,9 @@ const server = http.createServer((req, res) => {
   const u = new URL(req.url, "http://x/");
   if (u.pathname === "/") return streamFile(path.join(UI_DIR, "index.html"), "text/html", res);
   if (u.pathname === "/preview.mjs") return streamFile(path.join(UI_DIR, "preview.mjs"), "text/javascript", res);
+  if (u.pathname === "/connection.mjs") return streamFile(path.join(UI_DIR, "connection.mjs"), "text/javascript", res);
+  if (u.pathname === "/ui-controls.mjs") return streamFile(path.join(UI_DIR, "ui-controls.mjs"), "text/javascript", res);
+  if (u.pathname === "/renderer.mjs") return streamFile(path.join(UI_DIR, "renderer.mjs"), "text/javascript", res);
   if (u.pathname === "/favicon.ico") return streamFile(path.join(UI_DIR, "favicon.ico"), "image/x-icon", res);
   if (u.pathname === "/effects.mjs") return streamFile(path.join(__dirname, "effects.mjs"), "text/javascript", res);
   if (u.pathname === "/layout/left") return sendJson(layoutLeft, res);

--- a/src/ui/connection.mjs
+++ b/src/ui/connection.mjs
@@ -1,0 +1,21 @@
+export let socket = null;
+
+export function initConnection(win, onInit, onParams, onError){
+  try {
+    socket = new win.WebSocket(`ws://${win.location.host}`);
+    socket.onerror = (ev)=>{ console.error("WebSocket error", ev); if(onError) onError("WebSocket connection error"); };
+    socket.onclose = (ev)=>{ console.warn("WebSocket closed", ev); if(onError) onError("WebSocket connection closed"); };
+    socket.onmessage = (ev)=>{
+      const m = JSON.parse(ev.data);
+      if (m.type === "init" && onInit) onInit(m);
+      if (m.type === "params" && onParams) onParams(m);
+    };
+  } catch(err){
+    console.error("Failed to create WebSocket", err);
+    if (onError) onError("Failed to connect to server");
+  }
+}
+
+export function send(obj){
+  if (socket && socket.readyState === 1) socket.send(JSON.stringify(obj));
+}

--- a/src/ui/preview.mjs
+++ b/src/ui/preview.mjs
@@ -1,220 +1,53 @@
-import {
-  genGradient, genSolid, genFire,
-  applyBrightnessTint, applyGamma, applyStrobe, applyRollX,
-  sliceSection, clamp01
-} from "../effects.mjs";
+import { initConnection, send } from "./connection.mjs";
+import { initUI, applyUI } from "./ui-controls.mjs";
+import { frame, toggleFreeze } from "./renderer.mjs";
 
-let doc = /** @type {Document} */ (globalThis.document);
-let win = /** @type {Window} */ (doc && doc.defaultView ? doc.defaultView : globalThis);
-
-const controls = [
-  "fpsCap", "mirrorWalls", "brightness", "gamma", "rollPx",
-  "strobeHz", "strobeDuty", "strobeLow", "gradPhase"
-];
-
-let ws = null;
-let P = null;
-let sceneW = 512, sceneH = 128;
-let layoutLeft = null, layoutRight = null;
-let canvL = null, ctxL = null;
-let canvR = null, ctxR = null;
-
-const leftF  = new Float32Array(sceneW * sceneH * 3);
-const rightF = new Float32Array(sceneW * sceneH * 3);
-
-let offscreen = null, offCtx = null;
-let freeze = false;
-
-function setStatus(docArg, msg){
-  const el = docArg.getElementById("status");
+function setStatus(doc, msg){
+  const el = doc.getElementById("status");
   if (el) el.textContent = msg;
 }
 
-function send(obj){
-  if (ws && ws.readyState === 1) ws.send(JSON.stringify(obj));
-}
-
-function applyUI(docArg = doc){
-  if (!P) return;
-  const effect = docArg.getElementById("effect");
-  if (effect && effect.value !== P.effect) effect.value = P.effect;
-  for (const k of controls) {
-    const el = docArg.getElementById(k);
-    const span = docArg.getElementById(k + "_v");
-    if (!el) continue;
-    if (el.type === "checkbox") el.checked = !!P[k];
-    else { el.value = P[k]; if (span) span.textContent = P[k]; }
+async function loadLayout(win, doc, side){
+  try {
+    return await (await win.fetch(`/layout/${side}`)).json();
+  } catch (err) {
+    console.error(`Failed to load ${side} layout`, err);
+    setStatus(doc, `Failed to load ${side} layout`);
+    return null;
   }
-  ["tintR","tintG","tintB"].forEach((id,i)=>{
-    const el = docArg.getElementById(id);
-    const span = docArg.getElementById(id + "_v");
-    if (!el) return;
-    el.value = P.tint[i];
-    if (span) span.textContent = P.tint[i];
-  });
-}
-
-export function initUI(docArg = doc){
-  // effect select
-  const effect = docArg.getElementById("effect");
-  effect.value = P.effect;
-  effect.onchange = () => send({ effect: effect.value });
-
-  // ranges/checkboxes
-  for (const k of controls) {
-    const el = docArg.getElementById(k);
-    const span = docArg.getElementById(k + "_v");
-    if (!el) continue;
-    if (el.type === "checkbox") {
-      el.checked = !!P[k];
-      el.oninput = () => send({ [k]: el.checked });
-    } else {
-      el.value = P[k];
-      if (span) span.textContent = P[k];
-      el.oninput = () => {
-        if (span) span.textContent = el.value;
-        send({ [k]: parseFloat(el.value) });
-      };
-    }
-  }
-
-  // tint sliders
-  ["tintR","tintG","tintB"].forEach((id, i) => {
-    const el = docArg.getElementById(id);
-    const span = docArg.getElementById(id + "_v");
-    el.value = P.tint[i];
-    if (span) span.textContent = P.tint[i];
-    el.oninput = () => {
-      P.tint[i] = parseFloat(el.value);
-      if (span) span.textContent = el.value;
-      send({ tint: P.tint });
-    };
-  });
-
-  // hotkeys
-  win.addEventListener("keydown", (e) => {
-    if (e.key === "1") effect.value = "gradient", effect.onchange();
-    if (e.key === "2") effect.value = "solid", effect.onchange();
-    if (e.key === "3") effect.value = "fire", effect.onchange();
-    if (e.key.toLowerCase() === "b") send({ brightness: 0 });
-    if (e.key === " ") freeze = !freeze;
-  });
-
-  applyUI(docArg);
-  if (layoutLeft && layoutRight) startPreview();
-  else setStatus(docArg, "Preview unavailable");
-}
-
-export function renderScene(target, side, t){
-  switch (P.effect) {
-    case "solid": genSolid(target, sceneW, sceneH, t, P, side); break;
-    case "fire":  genFire(target,  sceneW, sceneH, t, P);      break;
-    default:      genGradient(target, sceneW, sceneH, t, P);    break;
-  }
-  applyStrobe(target, t, P.strobeHz, P.strobeDuty, P.strobeLow);
-  applyBrightnessTint(target, P.tint, P.brightness);
-  applyGamma(target, P.gamma);
-  applyRollX(target, sceneW, sceneH, P.rollPx);
-}
-
-export function drawScene(ctx, sceneF32, docArg = doc){
-  if (!offscreen || offscreen.width !== sceneW || offscreen.height !== sceneH) {
-    if (win.OffscreenCanvas) {
-      offscreen = new win.OffscreenCanvas(sceneW, sceneH);
-    } else {
-      offscreen = docArg.createElement("canvas");
-      offscreen.width = sceneW;
-      offscreen.height = sceneH;
-    }
-    offCtx = offscreen.getContext("2d");
-  }
-  const img = offCtx.createImageData(sceneW, sceneH);
-  for (let i = 0, j = 0; i < sceneF32.length; i += 3, j += 4){
-    img.data[j]   = Math.round(clamp01(sceneF32[i]) * 255);
-    img.data[j+1] = Math.round(clamp01(sceneF32[i+1]) * 255);
-    img.data[j+2] = Math.round(clamp01(sceneF32[i+2]) * 255);
-    img.data[j+3] = 255;
-  }
-  offCtx.putImageData(img, 0, 0);
-  ctx.imageSmoothingEnabled = false;
-  ctx.clearRect(0,0,ctx.canvas.width,ctx.canvas.height);
-  ctx.drawImage(offscreen, 0, 0, ctx.canvas.width, ctx.canvas.height);
-}
-
-function drawSections(ctx, sceneF32, layout){
-  const Wc = ctx.canvas.width, Hc = ctx.canvas.height;
-  ctx.lineWidth = 2; ctx.strokeStyle = "rgba(255,255,255,0.6)";
-  layout.runs.forEach(run => {
-    run.sections.forEach(sec => {
-      const y = sec.y * Hc;
-      const x0 = (sec.x0 / layout.sampling.width) * Wc;
-      const x1 = (sec.x1 / layout.sampling.width) * Wc;
-
-      ctx.beginPath(); ctx.moveTo(x0, y); ctx.lineTo(x1, y); ctx.stroke();
-
-      const bytes = sliceSection(sceneF32, sceneW, sceneH, sec, layout.sampling);
-      for (let i = 0; i < sec.led_count; i++){
-        const t = sec.led_count > 1 ? i / (sec.led_count - 1) : 0;
-        const x = x0 + (x1 - x0) * t;
-        const j = i * 3;
-        ctx.fillStyle = `rgb(${bytes[j]},${bytes[j+1]},${bytes[j+2]})`;
-        ctx.fillRect(x-1, y-1, 2, 2);
-      }
-    });
-  });
-}
-
-function frame(){
-  const t = freeze ? 0 : win.performance.now() / 1000;
-  renderScene(leftF,  "left",  t);
-  if (P.mirrorWalls) rightF.set(leftF); else renderScene(rightF, "right", t);
-  drawScene(ctxL, leftF);
-  if (layoutLeft)  drawSections(ctxL, leftF, layoutLeft);
-  drawScene(ctxR, rightF);
-  if (layoutRight) drawSections(ctxR, rightF, layoutRight);
-  win.requestAnimationFrame(frame);
-}
-
-export function startPreview(){
-  win.requestAnimationFrame(frame);
 }
 
 export async function boot(docArg = globalThis.document){
-  doc = docArg;
-  win = docArg.defaultView || globalThis;
+  const doc = docArg;
+  const win = docArg.defaultView || globalThis;
 
-  try {
-    ws = new win.WebSocket(`ws://${win.location.host}`);
-    ws.onerror = (ev)=>{ console.error("WebSocket error", ev); setStatus(doc, "WebSocket connection error"); };
-    ws.onclose = (ev)=>{ console.warn("WebSocket closed", ev); setStatus(doc, "WebSocket connection closed"); };
-    ws.onmessage = (ev)=> {
-      const m = JSON.parse(ev.data);
-      if (m.type === "init") { P = m.params; sceneW = m.scene.w; sceneH = m.scene.h; initUI(doc); }
-      if (m.type === "params") { P = m.params; applyUI(doc); }
-    };
-  } catch (err) {
-    console.error("Failed to create WebSocket", err);
-    setStatus(doc, "Failed to connect to server");
-  }
+  const [layoutLeft, layoutRight] = await Promise.all([
+    loadLayout(win, doc, "left"),
+    loadLayout(win, doc, "right")
+  ]);
 
-  try {
-    layoutLeft = await (await win.fetch("/layout/left")).json();
-  } catch (err) {
-    console.error("Failed to load left layout", err);
-    setStatus(doc, "Failed to load left layout");
-  }
-  try {
-    layoutRight = await (await win.fetch("/layout/right")).json();
-  } catch (err) {
-    console.error("Failed to load right layout", err);
-    setStatus(doc, "Failed to load right layout");
-  }
+  const canvL = doc.getElementById("left");
+  const ctxL = canvL.getContext("2d");
+  const canvR = doc.getElementById("right");
+  const ctxR = canvR.getContext("2d");
 
-  canvL = doc.getElementById("left");
-  ctxL = canvL.getContext("2d");
-  canvR = doc.getElementById("right");
-  ctxR = canvR.getContext("2d");
+  const params = {};
+
+  initConnection(win,
+    (m) => {
+      Object.assign(params, m.params);
+      const sceneW = m.scene.w;
+      const sceneH = m.scene.h;
+      const leftF  = new Float32Array(sceneW * sceneH * 3);
+      const rightF = new Float32Array(sceneW * sceneH * 3);
+      initUI(win, doc, params, send, toggleFreeze);
+      if (ctxL && ctxR) frame(win, doc, ctxL, ctxR, leftF, rightF, params, layoutLeft, layoutRight, sceneW, sceneH);
+      else setStatus(doc, "Preview unavailable");
+    },
+    (m) => {
+      Object.assign(params, m.params);
+      applyUI(doc, params);
+    },
+    (msg) => setStatus(doc, msg)
+  );
 }
-
-export { P, sceneW, sceneH, layoutLeft, layoutRight };
-

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -3,5 +3,8 @@
 Browser interface providing live preview and controls.
 
 - `index.html` – control layout and canvas elements.
-- `preview.mjs` – draws preview scenes and syncs params over WebSocket.
+- `connection.mjs` – WebSocket setup and message handling.
+- `ui-controls.mjs` – reads and updates DOM controls.
+- `renderer.mjs` – scene generation and drawing.
+- `preview.mjs` – bootstrap wiring modules together.
 - `favicon.ico` – page icon.

--- a/src/ui/renderer.mjs
+++ b/src/ui/renderer.mjs
@@ -1,0 +1,82 @@
+import {
+  genGradient, genSolid, genFire,
+  applyBrightnessTint, applyGamma, applyStrobe, applyRollX,
+  sliceSection, clamp01
+} from "../effects.mjs";
+
+let offscreen = null, offCtx = null;
+let freeze = false;
+
+export function toggleFreeze(){
+  freeze = !freeze;
+}
+
+export function renderScene(target, side, t, P, sceneW, sceneH){
+  switch (P.effect) {
+    case "solid": genSolid(target, sceneW, sceneH, t, P, side); break;
+    case "fire":  genFire(target,  sceneW, sceneH, t, P);      break;
+    default:      genGradient(target, sceneW, sceneH, t, P);    break;
+  }
+  applyStrobe(target, t, P.strobeHz, P.strobeDuty, P.strobeLow);
+  applyBrightnessTint(target, P.tint, P.brightness);
+  applyGamma(target, P.gamma);
+  applyRollX(target, sceneW, sceneH, P.rollPx);
+}
+
+export function drawScene(ctx, sceneF32, sceneW, sceneH, win, doc){
+  if (!offscreen || offscreen.width !== sceneW || offscreen.height !== sceneH){
+    if (win.OffscreenCanvas){
+      offscreen = new win.OffscreenCanvas(sceneW, sceneH);
+    } else {
+      offscreen = doc.createElement("canvas");
+      offscreen.width = sceneW;
+      offscreen.height = sceneH;
+    }
+    offCtx = offscreen.getContext("2d");
+  }
+  const img = offCtx.createImageData(sceneW, sceneH);
+  for (let i = 0, j = 0; i < sceneF32.length; i += 3, j += 4){
+    img.data[j]   = Math.round(clamp01(sceneF32[i]) * 255);
+    img.data[j+1] = Math.round(clamp01(sceneF32[i+1]) * 255);
+    img.data[j+2] = Math.round(clamp01(sceneF32[i+2]) * 255);
+    img.data[j+3] = 255;
+  }
+  offCtx.putImageData(img, 0, 0);
+  ctx.imageSmoothingEnabled = false;
+  ctx.clearRect(0,0,ctx.canvas.width,ctx.canvas.height);
+  ctx.drawImage(offscreen, 0, 0, ctx.canvas.width, ctx.canvas.height);
+}
+
+function drawSections(ctx, sceneF32, layout, sceneW, sceneH){
+  const Wc = ctx.canvas.width, Hc = ctx.canvas.height;
+  ctx.lineWidth = 2; ctx.strokeStyle = "rgba(255,255,255,0.6)";
+  layout.runs.forEach(run => {
+    run.sections.forEach(sec => {
+      const y = sec.y * Hc;
+      const x0 = (sec.x0 / layout.sampling.width) * Wc;
+      const x1 = (sec.x1 / layout.sampling.width) * Wc;
+
+      ctx.beginPath(); ctx.moveTo(x0, y); ctx.lineTo(x1, y); ctx.stroke();
+
+      const bytes = sliceSection(sceneF32, sceneW, sceneH, sec, layout.sampling);
+      for (let i = 0; i < sec.led_count; i++){
+        const t = sec.led_count > 1 ? i / (sec.led_count - 1) : 0;
+        const x = x0 + (x1 - x0) * t;
+        const j = i * 3;
+        ctx.fillStyle = `rgb(${bytes[j]},${bytes[j+1]},${bytes[j+2]})`;
+        ctx.fillRect(x-1, y-1, 2, 2);
+      }
+    });
+  });
+}
+
+export function frame(win, doc, ctxL, ctxR, leftF, rightF, P, layoutLeft, layoutRight, sceneW, sceneH){
+  const t = freeze ? 0 : win.performance.now() / 1000;
+  renderScene(leftF, "left", t, P, sceneW, sceneH);
+  if (P.mirrorWalls) rightF.set(leftF); else renderScene(rightF, "right", t, P, sceneW, sceneH);
+  drawScene(ctxL, leftF, sceneW, sceneH, win, doc);
+  if (layoutLeft)  drawSections(ctxL, leftF, layoutLeft, sceneW, sceneH);
+  drawScene(ctxR, rightF, sceneW, sceneH, win, doc);
+  if (layoutRight) drawSections(ctxR, rightF, layoutRight, sceneW, sceneH);
+  win.requestAnimationFrame(()=>frame(win, doc, ctxL, ctxR, leftF, rightF, P, layoutLeft, layoutRight, sceneW, sceneH));
+}

--- a/src/ui/ui-controls.mjs
+++ b/src/ui/ui-controls.mjs
@@ -1,0 +1,65 @@
+const controls = [
+  "fpsCap", "mirrorWalls", "brightness", "gamma", "rollPx",
+  "strobeHz", "strobeDuty", "strobeLow", "gradPhase"
+];
+
+export function applyUI(doc, P){
+  const effect = doc.getElementById("effect");
+  if (effect && effect.value !== P.effect) effect.value = P.effect;
+  for (const k of controls){
+    const el = doc.getElementById(k);
+    const span = doc.getElementById(k + "_v");
+    if (!el) continue;
+    if (el.type === "checkbox") el.checked = !!P[k];
+    else { el.value = P[k]; if (span) span.textContent = P[k]; }
+  }
+  ["tintR","tintG","tintB"].forEach((id,i)=>{
+    const el = doc.getElementById(id);
+    const span = doc.getElementById(id + "_v");
+    if (!el) return;
+    el.value = P.tint[i];
+    if (span) span.textContent = P.tint[i];
+  });
+}
+
+export function initUI(win, doc, P, send, onToggleFreeze){
+  const effect = doc.getElementById("effect");
+  effect.value = P.effect;
+  effect.onchange = () => send({ effect: effect.value });
+
+  for (const k of controls){
+    const el = doc.getElementById(k);
+    const span = doc.getElementById(k + "_v");
+    if (!el) continue;
+    if (el.type === "checkbox"){
+      el.checked = !!P[k];
+      el.oninput = () => send({ [k]: el.checked });
+    } else {
+      el.value = P[k];
+      if (span) span.textContent = P[k];
+      el.oninput = () => { if (span) span.textContent = el.value; send({ [k]: parseFloat(el.value) }); };
+    }
+  }
+
+  ["tintR","tintG","tintB"].forEach((id,i)=>{
+    const el = doc.getElementById(id);
+    const span = doc.getElementById(id + "_v");
+    el.value = P.tint[i];
+    if (span) span.textContent = P.tint[i];
+    el.oninput = () => {
+      P.tint[i] = parseFloat(el.value);
+      if (span) span.textContent = el.value;
+      send({ tint: P.tint });
+    };
+  });
+
+  win.addEventListener("keydown", (e) => {
+    if (e.key === "1") effect.value = "gradient", effect.onchange();
+    if (e.key === "2") effect.value = "solid", effect.onchange();
+    if (e.key === "3") effect.value = "fire", effect.onchange();
+    if (e.key.toLowerCase() === "b") send({ brightness: 0 });
+    if (e.key === " ") onToggleFreeze();
+  });
+
+  applyUI(doc, P);
+}


### PR DESCRIPTION
## Summary
- Split preview logic into separate modules for connection handling, UI controls, and rendering
- Refactor `preview.mjs` into a lightweight bootstrap that wires the new modules together
- Serve the new modules and document the updated UI structure

## Testing
- `npm test` *(fails: Failed to launch the browser process: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac846ad4bc8322bdfd13bf54989792