### PR TITLE
refactor effects into modular registry

### DIFF
--- a/src/effects/index.mjs
+++ b/src/effects/index.mjs
@@ -1,0 +1,9 @@
+import * as gradient from './library/gradient.mjs';
+import * as solid from './library/solid.mjs';
+import * as fire from './library/fire.mjs';
+
+export const effects = {
+  [gradient.id]: gradient,
+  [solid.id]: solid,
+  [fire.id]: fire,
+};

--- a/src/effects/library/fire.mjs
+++ b/src/effects/library/fire.mjs
@@ -1,0 +1,41 @@
+import { clamp01 } from '../modifiers.mjs';
+
+const mix = (a,b,t)=> a + (b-a)*t;
+const mix3 = (A,B,t)=> [mix(A[0],B[0],t), mix(A[1],B[1],t), mix(A[2],B[2],t)];
+function vnoise2(x,y){
+  return 0.5 + 0.5 * Math.sin( (x*12.9898 + y*78.233) * 43758.5453 );
+}
+function fbm(x,y,oct=4){
+  let a=0, f=1, amp=0.5;
+  for(let i=0;i<oct;i++){ a += amp*vnoise2(x*f,y*f); f*=2; amp*=0.5; }
+  return a;
+}
+
+export const id = 'fire';
+export const displayName = 'Fire';
+export const defaultParams = {
+  fireSpeed: 0.35,
+  fireScale: 2.2,
+  fireIntensity: 1.2,
+};
+export const paramSchema = {
+  fireSpeed:     { type: 'float' },
+  fireScale:     { type: 'float' },
+  fireIntensity: { type: 'float' },
+};
+
+export function render(sceneF32, W, H, t, params){
+  const { fireSpeed=0.35, fireScale=2.2, fireIntensity=1.2 } = params;
+  for(let y=0;y<H;y++){
+    for(let x=0;x<W;x++){
+      const n = fbm(x/(W/fireScale), (y/(H/fireScale)) - t*fireSpeed, 4);
+      const heat = Math.pow(clamp01(n*1.2 - (1 - y/H)*0.6), 1.2) * fireIntensity;
+      let rgb;
+      if (heat < 0.33)      rgb = mix3([0,0,0],[1,0,0], heat/0.33);
+      else if (heat<0.66)   rgb = mix3([1,0,0],[1,0.5,0], (heat-0.33)/0.33);
+      else                  rgb = mix3([1,0.5,0],[1,1,1], (heat-0.66)/0.34);
+      const i=(y*W+x)*3;
+      sceneF32[i]=rgb[0]; sceneF32[i+1]=rgb[1]; sceneF32[i+2]=rgb[2];
+    }
+  }
+}

--- a/src/effects/library/gradient.mjs
+++ b/src/effects/library/gradient.mjs
@@ -1,0 +1,27 @@
+const mix = (a,b,t)=> a + (b-a)*t;
+const mix3 = (A,B,t)=> [mix(A[0],B[0],t), mix(A[1],B[1],t), mix(A[2],B[2],t)];
+
+export const id = 'gradient';
+export const displayName = 'Gradient';
+export const defaultParams = {
+  gradStart: [0.0, 0.0, 1.0],
+  gradEnd:   [1.0, 0.0, 0.0],
+  gradPhase: 0.0,
+};
+export const paramSchema = {
+  gradStart: { type: 'rgb' },
+  gradEnd:   { type: 'rgb' },
+  gradPhase: { type: 'float' },
+};
+
+export function render(sceneF32, W, H, t, params){
+  const { gradStart, gradEnd, gradPhase=0 } = params;
+  for(let y=0;y<H;y++){
+    for(let x=0;x<W;x++){
+      const u = (x/W + gradPhase) % 1;
+      const rgb = mix3(gradStart, gradEnd, u);
+      const i=(y*W+x)*3;
+      sceneF32[i]=rgb[0]; sceneF32[i+1]=rgb[1]; sceneF32[i+2]=rgb[2];
+    }
+  }
+}

--- a/src/effects/library/readme.md
+++ b/src/effects/library/readme.md
@@ -1,0 +1,4 @@
+# Effect Library
+
+One file per visual effect. Each module exports:
+`{ id, displayName, defaultParams, paramSchema, render }`.

--- a/src/effects/library/solid.mjs
+++ b/src/effects/library/solid.mjs
@@ -1,0 +1,17 @@
+export const id = 'solid';
+export const displayName = 'Solid';
+export const defaultParams = {
+  solidLeft:  [0.0, 1.0, 0.0],
+  solidRight: [1.0, 1.0, 1.0],
+};
+export const paramSchema = {
+  solidLeft:  { type: 'rgb' },
+  solidRight: { type: 'rgb' },
+};
+
+export function render(sceneF32, W, H, t, params, side){
+  const rgb = side === 'left' ? params.solidLeft : params.solidRight;
+  for(let i=0;i<sceneF32.length;i+=3){
+    sceneF32[i]=rgb[0]; sceneF32[i+1]=rgb[1]; sceneF32[i+2]=rgb[2];
+  }
+}

--- a/src/effects/modifiers.mjs
+++ b/src/effects/modifiers.mjs
@@ -1,57 +1,7 @@
-// src/effects.mjs
-
-// ---------- utilities ----------
 export const clamp01 = (x) => Math.max(0, Math.min(1, x));
-const mix = (a,b,t)=> a + (b-a)*t;
-const mix3 = (A,B,t)=> [mix(A[0],B[0],t), mix(A[1],B[1],t), mix(A[2],B[2],t)];
 
-// ---------- noise for fire (fast "value noise" + FBM) ----------
-function vnoise2(x,y){
-  return 0.5 + 0.5 * Math.sin( (x*12.9898 + y*78.233) * 43758.5453 );
-}
-function fbm(x,y,oct=4){
-  let a=0, f=1, amp=0.5;
-  for(let i=0;i<oct;i++){ a += amp*vnoise2(x*f,y*f); f*=2; amp*=0.5; }
-  return a;
-}
-
-// ---------- generators (Stage A) ----------
-export function genGradient(sceneF32, W, H, t, params) {
-  const { gradStart, gradEnd, gradPhase=0 } = params;
-  for(let y=0;y<H;y++){
-    for(let x=0;x<W;x++){
-      const u = (x/W + gradPhase) % 1;
-      const rgb = mix3(gradStart, gradEnd, u);
-      const i=(y*W+x)*3;
-      sceneF32[i]=rgb[0]; sceneF32[i+1]=rgb[1]; sceneF32[i+2]=rgb[2];
-    }
-  }
-}
-
-export function genSolid(sceneF32, W, H, t, params, side) {
-  const rgb = side==="left" ? params.solidLeft : params.solidRight;
-  for(let i=0;i<sceneF32.length;i+=3){ sceneF32[i]=rgb[0]; sceneF32[i+1]=rgb[1]; sceneF32[i+2]=rgb[2]; }
-}
-
-export function genFire(sceneF32, W, H, t, params) {
-  const { fireSpeed=0.35, fireScale=2.2, fireIntensity=1.2 } = params;
-  for(let y=0;y<H;y++){
-    for(let x=0;x<W;x++){
-      const n = fbm(x/(W/fireScale), (y/(H/fireScale)) - t*fireSpeed, 4);
-      const heat = Math.pow(clamp01(n*1.2 - (1 - y/H)*0.6), 1.2) * fireIntensity;
-      let rgb;
-      if (heat < 0.33)      rgb = mix3([0,0,0],[1,0,0], heat/0.33);
-      else if (heat<0.66)   rgb = mix3([1,0,0],[1,0.5,0], (heat-0.33)/0.33);
-      else                  rgb = mix3([1,0.5,0],[1,1,1], (heat-0.66)/0.34);
-      const i=(y*W+x)*3;
-      sceneF32[i]=rgb[0]; sceneF32[i+1]=rgb[1]; sceneF32[i+2]=rgb[2];
-    }
-  }
-}
-
-// ---------- modifiers (Stage B) ----------
 export function applyBrightnessTint(sceneF32, tint, brightness){
-  const [tr,tg,tb]=tint; const g=brightness;
+  const [tr,tg,tb] = tint; const g = brightness;
   for(let i=0;i<sceneF32.length;i+=3){
     sceneF32[i]   = clamp01(sceneF32[i]  * tr * g);
     sceneF32[i+1] = clamp01(sceneF32[i+1]* tg * g);
@@ -90,7 +40,6 @@ export function applyRollX(sceneF32, W, H, px){
   }
 }
 
-// ---------- sampling (Stage C) ----------
 export function bilinearSampleRGB(sceneF32, W, H, sx, sy){
   sx = Math.max(0, Math.min(W-1, sx));
   sy = Math.max(0, Math.min(H-1, sy));

--- a/src/effects/readme.md
+++ b/src/effects/readme.md
@@ -1,0 +1,7 @@
+# Effects
+
+Effect modules and utilities for the renderer.
+
+- `library/` – individual effect implementations (e.g. gradient, solid, fire).
+- `index.mjs` – aggregates the library into an `effects` map keyed by id.
+- `modifiers.mjs` – shared modifiers and sampling helpers.

--- a/src/engine.mjs
+++ b/src/engine.mjs
@@ -3,11 +3,11 @@ import { readFile } from "fs/promises";
 import path from "path";
 import url from "url";
 
+import { effects } from "./effects/index.mjs";
 import {
-  genGradient, genSolid, genFire,
   applyBrightnessTint, applyGamma, applyStrobe, applyRollX,
   sliceSection, clamp01
-} from "./effects.mjs";
+} from "./effects/modifiers.mjs";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -68,11 +68,8 @@ function renderSceneForSide(side, t){
   const target = side==="left" ? leftF : rightF;
 
   // Stage A
-  switch (params.effect) {
-    case "solid":    genSolid(target, SCENE_W, SCENE_H, t, params, side); break;
-    case "fire":     genFire(target,  SCENE_W, SCENE_H, t, params);       break;
-    default:         genGradient(target, SCENE_W, SCENE_H, t, params);     break;
-  }
+  const effect = effects[params.effect] || effects["gradient"];
+  effect.render(target, SCENE_W, SCENE_H, t, params, side);
 
   // Stage B
   applyStrobe(target, t, params.strobeHz, params.strobeDuty, params.strobeLow);

--- a/src/readme.md
+++ b/src/readme.md
@@ -2,7 +2,7 @@
 
 Core runtime code for BarnLights Playbox:
 
-- `engine.mjs` – render loop emitting SLICES_NDJSON and exposing live `params`.
-- `server.mjs` – HTTP/WebSocket server serving the UI and applying param updates.
-- `effects.mjs` – effect generators and post-processing helpers.
-- `ui/` – browser UI for preview and controls.
+ - `engine.mjs` – render loop emitting SLICES_NDJSON and exposing live `params`.
+ - `server.mjs` – HTTP/WebSocket server serving the UI and applying param updates.
+ - `effects/` – effect implementations, registry and shared modifiers.
+ - `ui/` – browser UI for preview and controls.

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -27,7 +27,10 @@ const server = http.createServer((req, res) => {
   if (u.pathname === "/ui-controls.mjs") return streamFile(path.join(UI_DIR, "ui-controls.mjs"), "text/javascript", res);
   if (u.pathname === "/renderer.mjs") return streamFile(path.join(UI_DIR, "renderer.mjs"), "text/javascript", res);
   if (u.pathname === "/favicon.ico") return streamFile(path.join(UI_DIR, "favicon.ico"), "image/x-icon", res);
-  if (u.pathname === "/effects.mjs") return streamFile(path.join(__dirname, "effects.mjs"), "text/javascript", res);
+  if (u.pathname.startsWith("/effects/")) {
+    const p = path.join(__dirname, u.pathname.slice(1));
+    return streamFile(p, "text/javascript", res);
+  }
   if (u.pathname === "/layout/left") return sendJson(layoutLeft, res);
   if (u.pathname === "/layout/right") return sendJson(layoutRight, res);
   res.writeHead(404).end("Not found");

--- a/src/ui/renderer.mjs
+++ b/src/ui/renderer.mjs
@@ -1,8 +1,8 @@
+import { effects } from "../effects/index.mjs";
 import {
-  genGradient, genSolid, genFire,
   applyBrightnessTint, applyGamma, applyStrobe, applyRollX,
   sliceSection, clamp01
-} from "../effects.mjs";
+} from "../effects/modifiers.mjs";
 
 let offscreen = null, offCtx = null;
 let freeze = false;
@@ -12,11 +12,8 @@ export function toggleFreeze(){
 }
 
 export function renderScene(target, side, t, P, sceneW, sceneH){
-  switch (P.effect) {
-    case "solid": genSolid(target, sceneW, sceneH, t, P, side); break;
-    case "fire":  genFire(target,  sceneW, sceneH, t, P);      break;
-    default:      genGradient(target, sceneW, sceneH, t, P);    break;
-  }
+  const effect = effects[P.effect] || effects["gradient"];
+  effect.render(target, sceneW, sceneH, t, P, side);
   applyStrobe(target, t, P.strobeHz, P.strobeDuty, P.strobeLow);
   applyBrightnessTint(target, P.tint, P.brightness);
   applyGamma(target, P.gamma);

--- a/test/effects-sampling.test.mjs
+++ b/test/effects-sampling.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'assert/strict';
-import { bilinearSampleRGB, sliceSection } from '../src/effects.mjs';
+import { bilinearSampleRGB, sliceSection } from '../src/effects/modifiers.mjs';
 
 // helper to compare arrays with numbers precisely
 const eq = (a, b) => assert.deepEqual(a.map(n => +n.toFixed(5)), b.map(n => +n.toFixed(5)));


### PR DESCRIPTION
## Summary
- break out gradient, solid, and fire effects into dedicated modules with ids, metadata, and render functions
- central effects registry and shared modifiers simplify engine and UI imports
- serve new effects directory from the dev server and document the new structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac9218e120832291b51a0302afcf75