### PR TITLE
Namespace effect and post params

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,16 +13,22 @@ Minimal Node + browser setup that:
 - `src/ui/` contains the browser preview and controls.
 
 Runtime parameters are grouped under `effects` for effect-specific settings
-and `post` for modifiers like brightness, tint and strobe.
+and `post` for modifiers like brightness, tint and strobe which can be applied ontop.
 
 ## Quick start
+1. Open your terminal
+2. Navigate to this directory
+3. Execute the commands (node v20-22 required)
 ```bash
-npm i
-npm start  # UI: http://localhost:8080
+npm install
+npm start
 ```
+4.  Go to `localhost:8080` in your browser
 
 ## Running tests
 ```bash
 npm test
 ```
 
+## Acknowledgements
+OpenAI's Codex, you are a boss. Welcome to the age of software on demand.

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,9 @@ Minimal Node + browser setup that:
 - `src/server.mjs` serves the UI and relays WebSocket param updates.
 - `src/ui/` contains the browser preview and controls.
 
+Runtime parameters are grouped under `effects` for effect-specific settings
+and `post` for modifiers like brightness, tint and strobe.
+
 ## Quick start
 ```bash
 npm i

--- a/src/effects/library/readme.md
+++ b/src/effects/library/readme.md
@@ -1,4 +1,5 @@
 # Effect Library
 
-One file per visual effect. Each module exports:
+One file per visual effect. Each module exports the following:
 `{ id, displayName, defaultParams, paramSchema, render }`.
+Note that this includes its own render function, and prameters for modification.

--- a/src/effects/readme.md
+++ b/src/effects/readme.md
@@ -5,3 +5,5 @@ Effect modules and utilities for the renderer.
 - `library/` – individual effect implementations (e.g. gradient, solid, fire).
 - `index.mjs` – aggregates the library into an `effects` map keyed by id.
 - `modifiers.mjs` – shared modifiers and sampling helpers.
+
+Each effect contains its own render function and declares its modifiable parameters. Modifiers, or 'post' effects are commonly available to be applied ontop of any of the modular plugin effects.

--- a/src/readme.md
+++ b/src/readme.md
@@ -5,7 +5,9 @@ Core runtime code for BarnLights Playbox:
 - `engine.mjs` – render loop emitting SLICES_NDJSON and exposing live `params`.
 - `server.mjs` – HTTP/WebSocket server serving the UI and applying param updates.
 - `effects/` – effect implementations, registry and shared modifiers.
-- `ui/` – browser UI for preview and controls.
+- `ui/` – browser UI for preview and controls, can modify the `params` which the engine renders.
 
-`params` now nests effect-specific values in `effects[id]` and post-processing
-options in `post`.
+# A note on the engine's use of effects
+
+Effects are like little plugins, they declare their own controls and these are rendered depending on what effect you choose.
+Their values are encoded in a nested field of `params`. Shared effects are applied after/ontop of the plugin effects and include strobe, tint, and brightness - there are primary keys in `params`& always present.

--- a/src/readme.md
+++ b/src/readme.md
@@ -2,7 +2,10 @@
 
 Core runtime code for BarnLights Playbox:
 
- - `engine.mjs` – render loop emitting SLICES_NDJSON and exposing live `params`.
- - `server.mjs` – HTTP/WebSocket server serving the UI and applying param updates.
- - `effects/` – effect implementations, registry and shared modifiers.
- - `ui/` – browser UI for preview and controls.
+- `engine.mjs` – render loop emitting SLICES_NDJSON and exposing live `params`.
+- `server.mjs` – HTTP/WebSocket server serving the UI and applying param updates.
+- `effects/` – effect implementations, registry and shared modifiers.
+- `ui/` – browser UI for preview and controls.
+
+`params` now nests effect-specific values in `effects[id]` and post-processing
+options in `post`.

--- a/src/ui/main.mjs
+++ b/src/ui/main.mjs
@@ -17,7 +17,7 @@ async function loadLightLayout(win, doc, side){
   }
 }
 
-export async function boot(docArg = globalThis.document){
+export async function run(docArg = globalThis.document){
   const doc = docArg;
   const win = docArg.defaultView || globalThis;
 

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -8,3 +8,4 @@ Browser interface providing live preview and controls.
 - `renderer.mjs` – scene generation and drawing.
 - `preview.mjs` – bootstrap wiring modules together.
 - `favicon.ico` – page icon.
+`ui-controls.mjs` now interacts with namespaced params (`effects` and `post`).

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -3,9 +3,9 @@
 Browser interface providing live preview and controls.
 
 - `index.html` – control layout and canvas elements grouped into General, Strobe and Tint sections.
+- `main.mjs` – entry point for JS logic, wiring modules together, exposes a 'run' function.
 - `connection.mjs` – WebSocket setup and message handling.
-- `ui-controls.mjs` – reads and updates DOM controls.
-- `renderer.mjs` – scene generation and drawing.
-- `preview.mjs` – bootstrap wiring modules together.
-- `favicon.ico` – page icon.
+- `ui-controls.mjs` – reads and updates effect controls.
+- `renderer.mjs` – scene generation and drawing (relies on render functions within each effect).
+
 `ui-controls.mjs` now interacts with namespaced params (`effects` and `post`).

--- a/src/ui/renderer.mjs
+++ b/src/ui/renderer.mjs
@@ -13,11 +13,13 @@ export function toggleFreeze(){
 
 export function renderScene(target, side, t, P, sceneW, sceneH){
   const effect = effects[P.effect] || effects["gradient"];
-  effect.render(target, sceneW, sceneH, t, P, side);
-  applyStrobe(target, t, P.strobeHz, P.strobeDuty, P.strobeLow);
-  applyBrightnessTint(target, P.tint, P.brightness);
-  applyGamma(target, P.gamma);
-  applyRollX(target, sceneW, sceneH, P.rollPx);
+  const effectParams = P.effects[effect.id] || {};
+  effect.render(target, sceneW, sceneH, t, effectParams, side);
+  const post = P.post;
+  applyStrobe(target, t, post.strobeHz, post.strobeDuty, post.strobeLow);
+  applyBrightnessTint(target, post.tint, post.brightness);
+  applyGamma(target, post.gamma);
+  applyRollX(target, sceneW, sceneH, post.rollPx);
 }
 
 export function drawScene(ctx, sceneF32, sceneW, sceneH, win, doc){


### PR DESCRIPTION
## Summary
- group runtime params into `effects` and `post` namespaces
- merge each effect's defaults into `params.effects[id]`
- route flat param patches into `effects[id]` or `post`
- render engine and preview from namespaced params

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac9492482c8322be10ed27764cd1cf