### PR TITLE
Add layout and configuration validation tests

### DIFF
--- a/src/engine.mjs
+++ b/src/engine.mjs
@@ -135,4 +135,7 @@ function tick(){
 
   setImmediate(tick);
 }
-tick();
+
+if (import.meta.url === url.pathToFileURL(process.argv[1]).href) {
+  tick();
+}

--- a/src/engine.mjs
+++ b/src/engine.mjs
@@ -1,5 +1,5 @@
 // src/engine.mjs
-import { readFile } from "fs/promises";
+import fs from "fs/promises";
 import path from "path";
 import url from "url";
 
@@ -46,8 +46,8 @@ export const params = {
 };
 
 // ------- load layouts -------
-async function loadLayout(name){
-  const raw = await readFile(path.join(CONFIG_DIR, `${name}.json`), "utf8");
+export async function loadLayout(name){
+  const raw = await fs.readFile(path.join(CONFIG_DIR, `${name}.json`), "utf8");
   const j = JSON.parse(raw);
   if (!j?.sampling?.width || !j?.sampling?.height) throw new Error(`${name}.json missing sampling.width/height`);
   return j;

--- a/src/engine.mjs
+++ b/src/engine.mjs
@@ -136,6 +136,7 @@ function tick(){
   setImmediate(tick);
 }
 
+// Only tick if we are running as the main process to prevent output swamping tests
 if (import.meta.url === url.pathToFileURL(process.argv[1]).href) {
   tick();
 }

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+
+const CONFIG_DIR = new URL('../config/', import.meta.url);
+
+async function loadConfigs(){
+  const entries = await readdir(CONFIG_DIR);
+  const configs = [];
+  for (const name of entries) {
+    if (!name.endsWith('.json')) continue;
+    const data = await readFile(new URL(name, CONFIG_DIR), 'utf8');
+    configs.push({ name, json: JSON.parse(data) });
+  }
+  return configs;
+}
+
+test('config LED counts are consistent', async () => {
+  const configs = await loadConfigs();
+  for (const { name, json } of configs) {
+    const runTotal = json.runs.reduce((sum, run) => sum + run.led_count, 0);
+    assert.equal(
+      runTotal,
+      json.total_leds,
+      `${name} total_leds mismatch`
+    );
+    for (const run of json.runs) {
+      const sectionTotal = run.sections.reduce((sum, s) => sum + s.led_count, 0);
+      assert.equal(
+        sectionTotal,
+        run.led_count,
+        `${name} run ${run.run_index} led_count mismatch`
+      );
+    }
+  }
+});
+
+test('sections stay within normalized sampling space', async () => {
+  const configs = await loadConfigs();
+  for (const { name, json } of configs) {
+    assert.equal(json.sampling.space, 'normalized');
+    const { width, height } = json.sampling;
+    for (const run of json.runs) {
+      for (const sec of run.sections) {
+        assert(sec.y >= 0 && sec.y <= height,
+          `${name} section ${sec.id} y ${sec.y} out of range`);
+        assert(
+          sec.x0 >= 0 && sec.x1 <= width && sec.x0 <= sec.x1,
+          `${name} section ${sec.id} x-range out of ${width}`
+        );
+      }
+    }
+  }
+});

--- a/test/engine-layout.test.mjs
+++ b/test/engine-layout.test.mjs
@@ -1,0 +1,16 @@
+import test, { mock } from 'node:test';
+import assert from 'assert/strict';
+import fs from 'fs/promises';
+
+test('loadLayout rejects missing sampling.width', async (t) => {
+  const { loadLayout } = await import('../src/engine.mjs');
+  mock.method(fs, 'readFile', async () => {
+    return JSON.stringify({ sampling: { height: 1 }, runs: [] });
+  });
+  t.after(() => mock.restoreAll());
+
+  await assert.rejects(
+    loadLayout('foo'),
+    /foo\.json missing sampling.width\/height/
+  );
+});

--- a/test/readme.md
+++ b/test/readme.md
@@ -1,0 +1,10 @@
+# Tests
+
+Automated checks for BarnLights Playbox:
+
+- `engine.test.mjs` – validates engine output and config section lengths.
+- `engine-layout.test.mjs` – ensures layout loading rejects malformed files.
+- `config.test.mjs` – verifies configuration LED totals and section bounds.
+- `web.test.mjs` – loads the browser preview and fails on console errors.
+
+Run with `npm test`.

--- a/test/readme.md
+++ b/test/readme.md
@@ -7,4 +7,6 @@ Automated checks for BarnLights Playbox:
 - `config.test.mjs` – verifies configuration LED totals and section bounds.
 - `web.test.mjs` – loads the browser preview and fails on console errors.
 
+The engine module only starts emitting frames when run directly, keeping test output clean.
+
 Run with `npm test`.


### PR DESCRIPTION
## Summary
- export `loadLayout` and use default fs import for easier mocking
- add layout error test for missing sampling width
- add config consistency tests for LED totals and normalized bounds
- document test suite

## Testing
- `npm test` *(hangs after running initial tests; engine output continues endlessly)*

------
https://chatgpt.com/codex/tasks/task_e_68ac915ebbb083229a62dd3efef27a4e