### PR TITLE
feat: dynamic effect controls

### DIFF
--- a/src/effects/library/fire.mjs
+++ b/src/effects/library/fire.mjs
@@ -19,9 +19,9 @@ export const defaultParams = {
   fireIntensity: 1.2,
 };
 export const paramSchema = {
-  fireSpeed:     { type: 'float' },
-  fireScale:     { type: 'float' },
-  fireIntensity: { type: 'float' },
+  fireSpeed:     { type: 'number', min: 0, max: 5, step: 0.01 },
+  fireScale:     { type: 'number', min: 0.5, max: 10, step: 0.1 },
+  fireIntensity: { type: 'number', min: 0, max: 3, step: 0.01 },
 };
 
 export function render(sceneF32, W, H, t, params){

--- a/src/effects/library/gradient.mjs
+++ b/src/effects/library/gradient.mjs
@@ -9,9 +9,9 @@ export const defaultParams = {
   gradPhase: 0.0,
 };
 export const paramSchema = {
-  gradStart: { type: 'rgb' },
-  gradEnd:   { type: 'rgb' },
-  gradPhase: { type: 'float' },
+  gradStart: { type: 'color' },
+  gradEnd:   { type: 'color' },
+  gradPhase: { type: 'number', min: 0, max: 1, step: 0.001 },
 };
 
 export function render(sceneF32, W, H, t, params){

--- a/src/effects/library/solid.mjs
+++ b/src/effects/library/solid.mjs
@@ -5,8 +5,8 @@ export const defaultParams = {
   solidRight: [1.0, 1.0, 1.0],
 };
 export const paramSchema = {
-  solidLeft:  { type: 'rgb' },
-  solidRight: { type: 'rgb' },
+  solidLeft:  { type: 'color' },
+  solidRight: { type: 'color' },
 };
 
 export function render(sceneF32, W, H, t, params, side){

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -23,9 +23,14 @@ const server = http.createServer((req, res) => {
   const u = new URL(req.url, "http://x/");
   if (u.pathname === "/") return streamFile(path.join(UI_DIR, "index.html"), "text/html", res);
   if (u.pathname === "/preview.mjs") return streamFile(path.join(UI_DIR, "preview.mjs"), "text/javascript", res);
+  if (u.pathname === "/main.mjs") return streamFile(path.join(UI_DIR, "main.mjs"), "text/javascript", res);
   if (u.pathname === "/connection.mjs") return streamFile(path.join(UI_DIR, "connection.mjs"), "text/javascript", res);
   if (u.pathname === "/ui-controls.mjs") return streamFile(path.join(UI_DIR, "ui-controls.mjs"), "text/javascript", res);
   if (u.pathname === "/renderer.mjs") return streamFile(path.join(UI_DIR, "renderer.mjs"), "text/javascript", res);
+  if (u.pathname.startsWith("/controls/")) {
+    const p = path.join(UI_DIR, u.pathname.slice(1));
+    return streamFile(p, "text/javascript", res);
+  }
   if (u.pathname === "/favicon.ico") return streamFile(path.join(UI_DIR, "favicon.ico"), "image/x-icon", res);
   if (u.pathname.startsWith("/effects/")) {
     const p = path.join(__dirname, u.pathname.slice(1));

--- a/src/ui/controls/checkbox.mjs
+++ b/src/ui/controls/checkbox.mjs
@@ -3,6 +3,7 @@ export function checkboxWidget(key, schema, values, send){
   label.textContent = schema.label || key;
   const input = document.createElement('input');
   input.type = 'checkbox';
+  input.dataset.key = key;
   input.checked = !!values[key];
   input.oninput = () => {
     const v = input.checked;

--- a/src/ui/controls/checkbox.mjs
+++ b/src/ui/controls/checkbox.mjs
@@ -1,0 +1,14 @@
+export function checkboxWidget(key, schema, values, send){
+  const label = document.createElement('label');
+  label.textContent = schema.label || key;
+  const input = document.createElement('input');
+  input.type = 'checkbox';
+  input.checked = !!values[key];
+  input.oninput = () => {
+    const v = input.checked;
+    values[key] = v;
+    send({ [key]: v });
+  };
+  label.appendChild(input);
+  return label;
+}

--- a/src/ui/controls/color.mjs
+++ b/src/ui/controls/color.mjs
@@ -5,6 +5,7 @@ export function colorWidget(key, schema, values, send){
   label.textContent = schema.label || key;
   const input = document.createElement('input');
   input.type = 'color';
+  input.dataset.key = key;
   const current = values[key] || schema.default || [1,1,1];
   input.value = Array.isArray(current) ? rgbToHex(current) : current;
   input.oninput = () => {

--- a/src/ui/controls/color.mjs
+++ b/src/ui/controls/color.mjs
@@ -1,0 +1,17 @@
+import { rgbToHex, hexToRgb } from './utils.mjs';
+
+export function colorWidget(key, schema, values, send){
+  const label = document.createElement('label');
+  label.textContent = schema.label || key;
+  const input = document.createElement('input');
+  input.type = 'color';
+  const current = values[key] || schema.default || [1,1,1];
+  input.value = Array.isArray(current) ? rgbToHex(current) : current;
+  input.oninput = () => {
+    const rgb = hexToRgb(input.value);
+    values[key] = rgb;
+    send({ [key]: rgb });
+  };
+  label.appendChild(input);
+  return label;
+}

--- a/src/ui/controls/colorStops.mjs
+++ b/src/ui/controls/colorStops.mjs
@@ -1,0 +1,52 @@
+import { rgbToHex, hexToRgb } from './utils.mjs';
+
+export function colorStopsWidget(key, schema, values, send){
+  const label = document.createElement('label');
+  label.textContent = schema.label || key;
+  const container = document.createElement('div');
+  container.style.display = 'flex';
+  container.style.flexDirection = 'column';
+  container.style.gap = '4px';
+  label.appendChild(container);
+
+  const stops = values[key] || [];
+  values[key] = stops;
+
+  function emit(){
+    send({ [key]: stops });
+  }
+
+  function render(){
+    container.innerHTML = '';
+    stops.forEach((stop,i)=>{
+      const row = document.createElement('div');
+      row.style.display = 'flex';
+      row.style.alignItems = 'center';
+      row.style.gap = '4px';
+
+      const pos = document.createElement('input');
+      pos.type = 'number'; pos.min = 0; pos.max = 1; pos.step = 0.01;
+      pos.value = stop.pos ?? 0;
+      pos.oninput = () => { stop.pos = parseFloat(pos.value); emit(); };
+
+      const col = document.createElement('input');
+      col.type = 'color';
+      col.value = rgbToHex(stop.color || [1,1,1]);
+      col.oninput = () => { stop.color = hexToRgb(col.value); emit(); };
+
+      const del = document.createElement('button');
+      del.type = 'button'; del.textContent = 'x';
+      del.onclick = () => { stops.splice(i,1); emit(); render(); };
+
+      row.append(pos, col, del);
+      container.appendChild(row);
+    });
+    const add = document.createElement('button');
+    add.type = 'button'; add.textContent = 'Add';
+    add.onclick = () => { stops.push({ pos: 0, color: [1,1,1] }); emit(); render(); };
+    container.appendChild(add);
+  }
+
+  render();
+  return label;
+}

--- a/src/ui/controls/enum.mjs
+++ b/src/ui/controls/enum.mjs
@@ -1,0 +1,24 @@
+export function enumWidget(key, schema, values, send){
+  const label = document.createElement('label');
+  label.textContent = schema.label || key;
+  const select = document.createElement('select');
+  (schema.values || []).forEach(opt => {
+    const o = document.createElement('option');
+    if (typeof opt === 'string') {
+      o.value = opt;
+      o.textContent = opt;
+    } else {
+      o.value = opt.value;
+      o.textContent = opt.label || opt.value;
+    }
+    select.appendChild(o);
+  });
+  select.value = values[key];
+  select.onchange = () => {
+    const v = select.value;
+    values[key] = v;
+    send({ [key]: v });
+  };
+  label.appendChild(select);
+  return label;
+}

--- a/src/ui/controls/enum.mjs
+++ b/src/ui/controls/enum.mjs
@@ -2,6 +2,7 @@ export function enumWidget(key, schema, values, send){
   const label = document.createElement('label');
   label.textContent = schema.label || key;
   const select = document.createElement('select');
+  select.dataset.key = key;
   (schema.values || []).forEach(opt => {
     const o = document.createElement('option');
     if (typeof opt === 'string') {

--- a/src/ui/controls/index.mjs
+++ b/src/ui/controls/index.mjs
@@ -1,0 +1,28 @@
+import { numberWidget } from './number.mjs';
+import { checkboxWidget } from './checkbox.mjs';
+import { enumWidget } from './enum.mjs';
+import { colorWidget } from './color.mjs';
+import { colorStopsWidget } from './colorStops.mjs';
+
+const widgets = {
+  number: numberWidget,
+  float: numberWidget,
+  checkbox: checkboxWidget,
+  enum: enumWidget,
+  color: colorWidget,
+  rgb: colorWidget,
+  colorStops: colorStopsWidget,
+};
+
+export function renderControls(schema, values, send){
+  const frag = document.createDocumentFragment();
+  if (!schema) return frag;
+  for (const [key, desc] of Object.entries(schema)){
+    const type = desc.type || 'number';
+    const widget = widgets[type];
+    if (!widget) continue;
+    const el = widget(key, desc, values, send);
+    if (el) frag.appendChild(el);
+  }
+  return frag;
+}

--- a/src/ui/controls/number.mjs
+++ b/src/ui/controls/number.mjs
@@ -2,6 +2,7 @@ export function numberWidget(key, schema, values, send){
   const label = document.createElement('label');
   label.textContent = schema.label || key;
   const input = document.createElement('input');
+  input.dataset.key = key;
   if (schema.min !== undefined && schema.max !== undefined){
     input.type = 'range';
     input.min = schema.min;

--- a/src/ui/controls/number.mjs
+++ b/src/ui/controls/number.mjs
@@ -1,0 +1,28 @@
+export function numberWidget(key, schema, values, send){
+  const label = document.createElement('label');
+  label.textContent = schema.label || key;
+  const input = document.createElement('input');
+  if (schema.min !== undefined && schema.max !== undefined){
+    input.type = 'range';
+    input.min = schema.min;
+    input.max = schema.max;
+    input.step = schema.step ?? 0.01;
+  } else {
+    input.type = 'number';
+    if (schema.min !== undefined) input.min = schema.min;
+    if (schema.max !== undefined) input.max = schema.max;
+    if (schema.step !== undefined) input.step = schema.step;
+  }
+  const span = document.createElement('span');
+  const setVal = v => { input.value = v; span.textContent = v; };
+  setVal(values[key] ?? schema.default ?? 0);
+  input.oninput = () => {
+    const v = parseFloat(input.value);
+    values[key] = v;
+    span.textContent = v;
+    send({ [key]: v });
+  };
+  label.appendChild(input);
+  label.appendChild(span);
+  return label;
+}

--- a/src/ui/controls/readme.md
+++ b/src/ui/controls/readme.md
@@ -1,0 +1,12 @@
+# Controls
+
+Dynamic UI widgets for effect parameters.
+
+- `index.mjs` – exports `renderControls` which builds form elements from a schema.
+- `number.mjs` – slider/number input.
+- `checkbox.mjs` – boolean toggle.
+- `enum.mjs` – dropdown selector.
+- `color.mjs` – RGB color picker.
+- `colorStops.mjs` – editable list of color/position pairs.
+
+Utilities for RGB conversions live in `utils.mjs`.

--- a/src/ui/controls/readme.md
+++ b/src/ui/controls/readme.md
@@ -10,3 +10,5 @@ Dynamic UI widgets for effect parameters.
 - `colorStops.mjs` – editable list of color/position pairs.
 
 Utilities for RGB conversions live in `utils.mjs`.
+
+Each widget marks its primary input with `data-key` so the host can sync values without re-rendering.

--- a/src/ui/controls/utils.mjs
+++ b/src/ui/controls/utils.mjs
@@ -1,0 +1,13 @@
+export function rgbToHex(rgb){
+  const [r,g,b] = rgb.map(v => Math.max(0, Math.min(255, Math.round(v*255))));
+  return '#' + [r,g,b].map(x => x.toString(16).padStart(2,'0')).join('');
+}
+
+export function hexToRgb(hex){
+  const h = hex.replace('#','');
+  return [
+    parseInt(h.slice(0,2),16)/255,
+    parseInt(h.slice(2,4),16)/255,
+    parseInt(h.slice(4,6),16)/255,
+  ];
+}

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -25,7 +25,7 @@
 <div class="panel">
   <fieldset>
     <legend>General</legend>
-    <div class="row">
+    <div class="row" id="effectRow">
       <label>Effect
         <select id="effect">
           <option>gradient</option>
@@ -33,7 +33,6 @@
           <option>fire</option>
         </select>
       </label>
-      <label>Gradient phase <input id="gradPhase" type="range" min="0" max="1" step="0.001"><span id="gradPhase_v"></span></label>
     </div>
 
     <div class="row">

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -24,8 +24,8 @@
   <div id="status"></div>
 <div class="panel">
   <fieldset>
-    <legend>General</legend>
-    <div class="row" id="effectRow">
+    <legend>Effect</legend>
+    <div class="row">
       <label>Effect
         <select id="effect">
           <option>gradient</option>
@@ -34,7 +34,11 @@
         </select>
       </label>
     </div>
+    <div class="row" id="effectControls"></div>
+  </fieldset>
 
+  <fieldset>
+    <legend>General</legend>
     <div class="row">
       <label>Brightness <input id="brightness" type="range" min="0" max="1" step="0.01"><span id="brightness_v"></span></label>
       <label>Gamma <input id="gamma" type="range" min="0.5" max="3" step="0.01"><span id="gamma_v"></span><small class="desc">brightness curve</small></label>

--- a/src/ui/preview.mjs
+++ b/src/ui/preview.mjs
@@ -1,0 +1,5 @@
+import { run } from './main.mjs';
+
+export function boot(){
+  run();
+}

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -5,7 +5,8 @@ Browser interface providing live preview and controls.
 - `index.html` – control layout and canvas elements grouped into General, Strobe and Tint sections.
 - `main.mjs` – entry point for JS logic, wiring modules together, exposes a 'run' function.
 - `connection.mjs` – WebSocket setup and message handling.
-- `ui-controls.mjs` – reads and updates effect controls.
+- `ui-controls.mjs` – wires DOM controls to params and renders effect-specific widgets.
+- `controls/` – reusable widgets and `renderControls` helper.
 - `renderer.mjs` – scene generation and drawing (relies on render functions within each effect).
 
 `ui-controls.mjs` now interacts with namespaced params (`effects` and `post`).

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -2,7 +2,7 @@
 
 Browser interface providing live preview and controls.
 
-- `index.html` – control layout and canvas elements grouped into General, Strobe and Tint sections.
+- `index.html` – control layout and canvas elements grouped into Effect, General, Strobe and Tint sections.
 - `main.mjs` – entry point for JS logic, wiring modules together, exposes a 'run' function.
 - `connection.mjs` – WebSocket setup and message handling.
 - `ui-controls.mjs` – wires DOM controls to params and renders effect-specific widgets.

--- a/src/ui/ui-controls.mjs
+++ b/src/ui/ui-controls.mjs
@@ -1,63 +1,88 @@
-const controls = [
-  "fpsCap", "mirrorWalls", "brightness", "gamma", "rollPx",
-  "strobeHz", "strobeDuty", "strobeLow", "gradPhase"
-];
+import { effects } from '../effects/index.mjs';
+import { renderControls } from './controls/index.mjs';
 
-function paramSource(P, key){
-  if (key === "fpsCap" || key === "mirrorWalls") return P;
-  if (key === "gradPhase") return P.effects.gradient;
-  return P.post;
+let sendFn = null;
+
+function renderEffectControls(doc, P){
+  const row = doc.getElementById('effectRow');
+  if (!row) return;
+  while (row.children.length > 1) row.removeChild(row.lastChild);
+  const effect = effects[P.effect] || effects['gradient'];
+  const schema = effect.paramSchema || {};
+  const values = P.effects[effect.id] = P.effects[effect.id] || {};
+  row.appendChild(renderControls(schema, values, (patch)=> sendFn(patch)));
 }
 
-export function applyUI(doc, P){
-  const effect = doc.getElementById("effect");
-  if (effect && effect.value !== P.effect) effect.value = P.effect;
-  for (const k of controls){
-    const el = doc.getElementById(k);
-    const span = doc.getElementById(k + "_v");
-    const src = paramSource(P, k);
-    if (!el || !src) continue;
-    const val = src[k];
-    if (el.type === "checkbox") el.checked = !!val;
+function applyTop(doc, P){
+  const fps = doc.getElementById('fpsCap');
+  const fpsV = doc.getElementById('fpsCap_v');
+  if (fps){ fps.value = P.fpsCap; if (fpsV) fpsV.textContent = P.fpsCap; }
+  const mirror = doc.getElementById('mirrorWalls');
+  if (mirror) mirror.checked = !!P.mirrorWalls;
+}
+
+function applyPost(doc, P){
+  for (const [key,val] of Object.entries(P.post)){
+    if (key === 'tint') continue;
+    const el = doc.getElementById(key);
+    const span = doc.getElementById(key + '_v');
+    if (!el) continue;
+    if (el.type === 'checkbox') el.checked = !!val;
     else { el.value = val; if (span) span.textContent = val; }
   }
-  ["tintR","tintG","tintB"].forEach((id,i)=>{
+  ['tintR','tintG','tintB'].forEach((id,i)=>{
     const el = doc.getElementById(id);
-    const span = doc.getElementById(id + "_v");
+    const span = doc.getElementById(id + '_v');
     if (!el) return;
     el.value = P.post.tint[i];
     if (span) span.textContent = P.post.tint[i];
   });
 }
 
-export function initUI(win, doc, P, send, onToggleFreeze){
-  const effect = doc.getElementById("effect");
-  effect.value = P.effect;
-  effect.onchange = () => send({ effect: effect.value });
+export function applyUI(doc, P){
+  const effect = doc.getElementById('effect');
+  if (effect && effect.value !== P.effect) effect.value = P.effect;
+  applyTop(doc,P);
+  applyPost(doc,P);
+  renderEffectControls(doc,P);
+}
 
-  for (const k of controls){
-    const el = doc.getElementById(k);
-    const span = doc.getElementById(k + "_v");
-    const src = paramSource(P, k);
-    if (!el || !src) continue;
-    if (el.type === "checkbox"){
-      el.checked = !!src[k];
-      el.oninput = () => { const s = paramSource(P, k); if(s){ s[k] = el.checked; } send({ [k]: el.checked }); };
+export function initUI(win, doc, P, send, onToggleFreeze){
+  sendFn = send;
+  const effect = doc.getElementById('effect');
+  effect.value = P.effect;
+  effect.onchange = () => { send({ effect: effect.value }); renderEffectControls(doc,P); };
+
+  const fps = doc.getElementById('fpsCap');
+  const fpsV = doc.getElementById('fpsCap_v');
+  if (fps){
+    fps.value = P.fpsCap;
+    if (fpsV) fpsV.textContent = P.fpsCap;
+    fps.oninput = () => { const v = parseFloat(fps.value); P.fpsCap = v; if (fpsV) fpsV.textContent = v; send({ fpsCap: v }); };
+  }
+  const mirror = doc.getElementById('mirrorWalls');
+  if (mirror){
+    mirror.checked = !!P.mirrorWalls;
+    mirror.oninput = () => { P.mirrorWalls = mirror.checked; send({ mirrorWalls: mirror.checked }); };
+  }
+  for (const [key,val] of Object.entries(P.post)){
+    if (key === 'tint') continue;
+    const el = doc.getElementById(key);
+    const span = doc.getElementById(key + '_v');
+    if (!el) continue;
+    if (el.type === 'checkbox'){
+      el.checked = !!val;
+      el.oninput = () => { P.post[key] = el.checked; send({ [key]: el.checked }); };
     } else {
-      el.value = src[k];
-      if (span) span.textContent = src[k];
-      el.oninput = () => {
-        const v = parseFloat(el.value);
-        const s = paramSource(P, k); if(s){ s[k] = v; }
-        if (span) span.textContent = v;
-        send({ [k]: v });
-      };
+      el.value = val;
+      if (span) span.textContent = val;
+      el.oninput = () => { const v = parseFloat(el.value); P.post[key] = v; if (span) span.textContent = v; send({ [key]: v }); };
     }
   }
-
-  ["tintR","tintG","tintB"].forEach((id,i)=>{
+  ['tintR','tintG','tintB'].forEach((id,i)=>{
     const el = doc.getElementById(id);
-    const span = doc.getElementById(id + "_v");
+    const span = doc.getElementById(id + '_v');
+    if (!el) return;
     el.value = P.post.tint[i];
     if (span) span.textContent = P.post.tint[i];
     el.oninput = () => {
@@ -68,12 +93,12 @@ export function initUI(win, doc, P, send, onToggleFreeze){
     };
   });
 
-  win.addEventListener("keydown", (e) => {
-    if (e.key === "1") effect.value = "gradient", effect.onchange();
-    if (e.key === "2") effect.value = "solid", effect.onchange();
-    if (e.key === "3") effect.value = "fire", effect.onchange();
-    if (e.key.toLowerCase() === "b") send({ brightness: 0 });
-    if (e.key === " ") onToggleFreeze();
+  win.addEventListener('keydown', (e) => {
+    if (e.key === '1') effect.value = 'gradient', effect.onchange();
+    if (e.key === '2') effect.value = 'solid', effect.onchange();
+    if (e.key === '3') effect.value = 'fire', effect.onchange();
+    if (e.key.toLowerCase() === 'b') send({ brightness: 0 });
+    if (e.key === ' ') onToggleFreeze();
   });
 
   applyUI(doc, P);


### PR DESCRIPTION
## Summary
- generate UI inputs from effect schemas via new `renderControls` helper
- add widget implementations for number, checkbox, enum, color and colorStops
- auto-wire effect parameters in `ui-controls.mjs` and expose new modules on the server

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad0192df088322b4cab60f11f31567