### PR TITLE
Add post-processing pipeline with registration

### DIFF
--- a/src/effects/post.mjs
+++ b/src/effects/post.mjs
@@ -1,0 +1,28 @@
+import {
+  applyBrightnessTint as _applyBrightnessTint,
+  applyGamma as _applyGamma,
+  applyStrobe as _applyStrobe,
+  applyRollX as _applyRollX,
+} from "./modifiers.mjs";
+
+function applyStrobe(sceneF32, t, post, W, H){
+  _applyStrobe(sceneF32, t, post.strobeHz, post.strobeDuty, post.strobeLow);
+}
+
+function applyBrightnessTint(sceneF32, t, post, W, H){
+  _applyBrightnessTint(sceneF32, post.tint, post.brightness);
+}
+
+function applyGamma(sceneF32, t, post, W, H){
+  _applyGamma(sceneF32, post.gamma);
+}
+
+function applyRollX(sceneF32, t, post, W, H){
+  _applyRollX(sceneF32, W, H, post.rollPx);
+}
+
+export const postPipeline = [applyStrobe, applyBrightnessTint, applyGamma, applyRollX];
+
+export function registerPostModifier(fn){
+  postPipeline.push(fn);
+}

--- a/src/effects/readme.md
+++ b/src/effects/readme.md
@@ -5,5 +5,7 @@ Effect modules and utilities for the renderer.
 - `library/` – individual effect implementations (e.g. gradient, solid, fire).
 - `index.mjs` – aggregates the library into an `effects` map keyed by id.
 - `modifiers.mjs` – shared modifiers and sampling helpers.
+- `post.mjs` – post-processing pipeline and modifier registration.
 
-Each effect contains its own render function and declares its modifiable parameters. Modifiers, or 'post' effects are commonly available to be applied ontop of any of the modular plugin effects.
+Each effect contains its own render function and declares its modifiable parameters. 
+Modifiers, or "post" effects, are commonly available to be applied on top of any plugin effect.

--- a/src/engine.mjs
+++ b/src/engine.mjs
@@ -4,14 +4,14 @@ import path from "path";
 import url from "url";
 
 import { effects } from "./effects/index.mjs";
-import {
-  applyBrightnessTint, applyGamma, applyStrobe, applyRollX,
-  sliceSection
-} from "./effects/modifiers.mjs";
+import { sliceSection } from "./effects/modifiers.mjs";
+import { postPipeline, registerPostModifier } from "./effects/post.mjs";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
 const CONFIG_DIR = path.join(ROOT, "config");
+
+export { registerPostModifier };
 
 export const SCENE_W = 512, SCENE_H = 128; // virtual canvas per side
 
@@ -85,10 +85,9 @@ function renderSceneForSide(side, t){
 
   // Stage B
   const post = params.post;
-  applyStrobe(target, t, post.strobeHz, post.strobeDuty, post.strobeLow);
-  applyBrightnessTint(target, post.tint, post.brightness);
-  applyGamma(target, post.gamma);
-  applyRollX(target, SCENE_W, SCENE_H, post.rollPx);
+  for (const fn of postPipeline) {
+    fn(target, t, post, SCENE_W, SCENE_H);
+  }
 }
 
 // ------- build slices frame -------

--- a/src/readme.md
+++ b/src/readme.md
@@ -4,10 +4,12 @@ Core runtime code for BarnLights Playbox:
 
 - `engine.mjs` – render loop emitting SLICES_NDJSON and exposing live `params`.
 - `server.mjs` – HTTP/WebSocket server serving the UI and applying param updates.
-- `effects/` – effect implementations, registry and shared modifiers.
+- `effects/` – effect implementations, registry and post-processing helpers.
 - `ui/` – browser UI for preview and controls, can modify the `params` which the engine renders.
 
-# A note on the engine's use of effects
+## A note on the engine's use of effects
 
-Effects are like little plugins, they declare their own controls and these are rendered depending on what effect you choose.
-Their values are encoded in a nested field of `params`. Shared effects are applied after/ontop of the plugin effects and include strobe, tint, and brightness - there are primary keys in `params`& always present.
+Effects are plugins that declare their own controls and are selected via `params.effect`.
+Their values live in `params.effects[effectId]`.
+Post-processing modifiers run afterwards via a pipeline defined in `effects/post.mjs`.
+Additional modifiers can be registered using `registerPostModifier` to extend the pipeline.

--- a/src/ui/renderer.mjs
+++ b/src/ui/renderer.mjs
@@ -1,8 +1,8 @@
 import { effects } from "../effects/index.mjs";
-import {
-  applyBrightnessTint, applyGamma, applyStrobe, applyRollX,
-  sliceSection, clamp01
-} from "../effects/modifiers.mjs";
+import { sliceSection, clamp01 } from "../effects/modifiers.mjs";
+import { postPipeline, registerPostModifier } from "../effects/post.mjs";
+
+export { registerPostModifier };
 
 let offscreen = null, offCtx = null;
 let freeze = false;
@@ -16,10 +16,9 @@ export function renderScene(target, side, t, P, sceneW, sceneH){
   const effectParams = P.effects[effect.id] || {};
   effect.render(target, sceneW, sceneH, t, effectParams, side);
   const post = P.post;
-  applyStrobe(target, t, post.strobeHz, post.strobeDuty, post.strobeLow);
-  applyBrightnessTint(target, post.tint, post.brightness);
-  applyGamma(target, post.gamma);
-  applyRollX(target, sceneW, sceneH, post.rollPx);
+  for (const fn of postPipeline) {
+    fn(target, t, post, sceneW, sceneH);
+  }
 }
 
 export function drawScene(ctx, sceneF32, sceneW, sceneH, win, doc){


### PR DESCRIPTION
## Summary
- Centralize post-processing modifiers in `post.mjs` with a default pipeline and registration hook
- Iterate the pipeline from engine and UI renderer for consistent post effects
- Document new pipeline and registration function

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad0801199c8322b171792a71221d54