### PR TITLE
Add shader-based fire effect

### DIFF
--- a/src/effects/index.mjs
+++ b/src/effects/index.mjs
@@ -1,9 +1,11 @@
 import * as gradient from './library/gradient.mjs';
 import * as solid from './library/solid.mjs';
 import * as fire from './library/fire.mjs';
+import * as fireShader from './library/fireShader.mjs';
 
 export const effects = {
   [gradient.id]: gradient,
   [solid.id]: solid,
   [fire.id]: fire,
+  [fireShader.id]: fireShader,
 };

--- a/src/effects/library/fireShader.mjs
+++ b/src/effects/library/fireShader.mjs
@@ -1,0 +1,102 @@
+import { clamp01 } from '../modifiers.mjs';
+
+// Value noise and FBM helpers
+function vnoise2(x, y){
+  return 0.5 + 0.5 * Math.sin((x * 12.9898 + y * 78.233) * 43758.5453);
+}
+
+function fbm(x, y, octaves = 4){
+  let amplitude = 0.5;
+  let frequency = 1.0;
+  let sum = 0.0;
+  for (let i = 0; i < octaves; i++){
+    sum += amplitude * vnoise2(x * frequency, y * frequency);
+    frequency *= 2.0;
+    amplitude *= 0.5;
+  }
+  return sum;
+}
+
+function lerp(a, b, t){
+  return a + (b - a) * t;
+}
+
+function mixColors(a, b, t){
+  return [
+    lerp(a[0], b[0], t),
+    lerp(a[1], b[1], t),
+    lerp(a[2], b[2], t),
+  ];
+}
+
+function sampleGradient(stops, t){
+  if (!stops.length) return [t, t, t];
+  if (t <= stops[0].pos) return stops[0].color;
+  for (let i = 0; i < stops.length - 1; i++){
+    const a = stops[i];
+    const b = stops[i + 1];
+    if (t <= b.pos){
+      const f = (t - a.pos) / Math.max(1e-6, b.pos - a.pos);
+      return mixColors(a.color, b.color, f);
+    }
+  }
+  return stops[stops.length - 1].color;
+}
+
+export const id = 'fireShader';
+export const displayName = 'Fire Shader';
+export const defaultParams = {
+  speed: 0.3,
+  angle: 0.0,
+  flameHeight: 1.5,
+  colors: [
+    { pos: 0.0, color: [0.0, 0.0, 0.0] },
+    { pos: 0.3, color: [1.0, 0.0, 0.0] },
+    { pos: 0.6, color: [1.0, 0.5, 0.0] },
+    { pos: 1.0, color: [1.0, 1.0, 1.0] },
+  ],
+};
+export const paramSchema = {
+  speed: { type: 'number', min: 0, max: 5, step: 0.01, label: 'Speed' },
+  angle: { type: 'number', min: -Math.PI, max: Math.PI, step: 0.01, label: 'Angle (rad)' },
+  flameHeight: { type: 'number', min: 0.1, max: 3, step: 0.01, label: 'Flame Height' },
+  colors: { type: 'colorStops', label: 'Colors' },
+};
+
+export function render(sceneF32, W, H, t, params){
+  const {
+    speed = defaultParams.speed,
+    angle = defaultParams.angle,
+    flameHeight = defaultParams.flameHeight,
+    colors = defaultParams.colors,
+  } = params || {};
+
+  const cosA = Math.cos(angle);
+  const sinA = Math.sin(angle);
+  const sortedStops = [...colors].sort((a, b) => a.pos - b.pos);
+
+  for (let y = 0; y < H; y++){
+    for (let x = 0; x < W; x++){
+      let u = x / W;
+      let v = y / H;
+
+      const cx = u - 0.5;
+      const cy = v - 0.5;
+      const rx = cx * cosA - cy * sinA;
+      const ry = cx * sinA + cy * cosA;
+      u = rx + 0.5;
+      v = ry + 0.5;
+
+      const noise = fbm(u * 3.0, (v * 3.0) - t * speed, 5);
+      const heightFactor = clamp01(1 - v * flameHeight);
+      const heat = clamp01(noise * heightFactor);
+      const rgb = sampleGradient(sortedStops, heat);
+
+      const i = (y * W + x) * 3;
+      sceneF32[i] = rgb[0];
+      sceneF32[i + 1] = rgb[1];
+      sceneF32[i + 2] = rgb[2];
+    }
+  }
+}
+

--- a/src/effects/library/readme.md
+++ b/src/effects/library/readme.md
@@ -2,4 +2,6 @@
 
 One file per visual effect. Each module exports the following:
 `{ id, displayName, defaultParams, paramSchema, render }`.
-Note that this includes its own render function, and prameters for modification.
+Note that this includes its own render function, and parameters for modification.
+
+Available effects include `gradient`, `solid`, `fire`, and the shader-based `fireShader`.

--- a/src/effects/readme.md
+++ b/src/effects/readme.md
@@ -2,7 +2,7 @@
 
 Effect modules and utilities for the renderer.
 
-- `library/` – individual effect implementations (e.g. gradient, solid, fire).
+- `library/` – individual effect implementations (e.g. gradient, solid, fire, fireShader).
 - `index.mjs` – aggregates the library into an `effects` map keyed by id.
 - `modifiers.mjs` – shared modifiers and sampling helpers.
 

--- a/src/ui/controls/readme.md
+++ b/src/ui/controls/readme.md
@@ -9,6 +9,8 @@ Dynamic UI widgets for effect parameters.
 - `color.mjs` – RGB color picker.
 - `colorStops.mjs` – editable list of color/position pairs.
 
+The `fireShader` effect uses the `colorStops` widget to define its color gradient.
+
 Utilities for RGB conversions live in `utils.mjs`.
 
 Each widget marks its primary input with `data-key` so the host can sync values without re-rendering.

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -31,6 +31,7 @@
           <option>gradient</option>
           <option>solid</option>
           <option>fire</option>
+          <option>fireShader</option>
         </select>
       </label>
     </div>
@@ -66,7 +67,7 @@
     </div>
   </fieldset>
 
-  <div>Hotkeys: <span class="kbd">1/2/3</span> effects, <span class="kbd">B</span> blackout (brightness=0), <span class="kbd">Space</span> freeze UI preview.</div>
+  <div>Hotkeys: <span class="kbd">1/2/3/4</span> effects, <span class="kbd">B</span> blackout (brightness=0), <span class="kbd">Space</span> freeze UI preview.</div>
 </div>
 
 <div class="barn">

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -9,4 +9,6 @@ Browser interface providing live preview and controls.
 - `controls/` – reusable widgets and `renderControls` helper.
 - `renderer.mjs` – scene generation and drawing (relies on render functions within each effect).
 
+The UI now includes a `fireShader` effect with adjustable speed, angle, flame height, and color gradient.
+
 `ui-controls.mjs` now interacts with namespaced params (`effects` and `post`).

--- a/src/ui/ui-controls.mjs
+++ b/src/ui/ui-controls.mjs
@@ -114,6 +114,7 @@ export function initUI(win, doc, P, send, onToggleFreeze){
     if (e.key === '1') effect.value = 'gradient', effect.onchange();
     if (e.key === '2') effect.value = 'solid', effect.onchange();
     if (e.key === '3') effect.value = 'fire', effect.onchange();
+    if (e.key === '4') effect.value = 'fireShader', effect.onchange();
     if (e.key.toLowerCase() === 'b') send({ brightness: 0 });
     if (e.key === ' ') onToggleFreeze();
   });


### PR DESCRIPTION
## Summary
- add `fireShader` effect using rotated FBM noise with gradient coloring
- expose shader params in UI and hotkey selection
- document new effect and gradient controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad0ab49c78832284b73ef295c9b7a6