### PR TITLE
Replace shader fire with CSS-based effect

### DIFF
--- a/src/effects/index.mjs
+++ b/src/effects/index.mjs
@@ -1,11 +1,11 @@
 import * as gradient from './library/gradient.mjs';
 import * as solid from './library/solid.mjs';
 import * as fire from './library/fire.mjs';
-import * as fireShader from './library/fireShader.mjs';
+import * as fireCss from './library/fireCss.mjs';
 
 export const effects = {
   [gradient.id]: gradient,
   [solid.id]: solid,
   [fire.id]: fire,
-  [fireShader.id]: fireShader,
+  [fireCss.id]: fireCss,
 };

--- a/src/effects/library/readme.md
+++ b/src/effects/library/readme.md
@@ -4,4 +4,4 @@ One file per visual effect. Each module exports the following:
 `{ id, displayName, defaultParams, paramSchema, render }`.
 Note that this includes its own render function, and parameters for modification.
 
-Available effects include `gradient`, `solid`, `fire`, and the shader-based `fireShader`.
+Available effects include `gradient`, `solid`, `fire`, and the CSS-driven `fireCss` with adjustable rotation, color gradient, and flame count.

--- a/src/effects/library/readme.md
+++ b/src/effects/library/readme.md
@@ -4,4 +4,4 @@ One file per visual effect. Each module exports the following:
 `{ id, displayName, defaultParams, paramSchema, render }`.
 Note that this includes its own render function, and parameters for modification.
 
-Available effects include `gradient`, `solid`, `fire`, and the CSS-driven `fireCss` with adjustable rotation, color gradient, and flame count.
+Available effects include `gradient`, `solid`, `fire`, and the CSS-driven `fireCss` with adjustable rotation, color gradient, flame count, and speed control.

--- a/src/effects/readme.md
+++ b/src/effects/readme.md
@@ -2,7 +2,7 @@
 
 Effect modules and utilities for the renderer.
 
-- `library/` – individual effect implementations (e.g. gradient, solid, fire, fireShader).
+- `library/` – individual effect implementations (e.g. gradient, solid, fire, fireCss).
 - `index.mjs` – aggregates the library into an `effects` map keyed by id.
 - `modifiers.mjs` – shared modifiers and sampling helpers.
 - `post.mjs` – post-processing pipeline and modifier registration.

--- a/src/effects/readme.md
+++ b/src/effects/readme.md
@@ -2,7 +2,7 @@
 
 Effect modules and utilities for the renderer.
 
-- `library/` – individual effect implementations (e.g. gradient, solid, fire, fireCss).
+- `library/` – individual effect implementations (e.g. gradient, solid, fire, fireCss with speed control).
 - `index.mjs` – aggregates the library into an `effects` map keyed by id.
 - `modifiers.mjs` – shared modifiers and sampling helpers.
 - `post.mjs` – post-processing pipeline and modifier registration.
@@ -10,3 +10,4 @@ Effect modules and utilities for the renderer.
 
 Each effect contains its own render function and declares its modifiable parameters. 
 Modifiers, or "post" effects, are commonly available to be applied on top of any plugin effect.
+

--- a/src/ui/controls/readme.md
+++ b/src/ui/controls/readme.md
@@ -9,7 +9,7 @@ Dynamic UI widgets for effect parameters.
 - `color.mjs` – RGB color picker.
 - `colorStops.mjs` – editable list of color/position pairs.
 
-The `fireShader` effect uses the `colorStops` widget to define its color gradient.
+The `fireCss` effect uses the `colorStops` widget to define its color gradient.
 
 Utilities for RGB conversions live in `utils.mjs`.
 

--- a/src/ui/controls/readme.md
+++ b/src/ui/controls/readme.md
@@ -9,8 +9,10 @@ Dynamic UI widgets for effect parameters.
 - `color.mjs` – RGB color picker.
 - `colorStops.mjs` – editable list of color/position pairs.
 
-The `fireCss` effect uses the `colorStops` widget to define its color gradient.
+The `fireCss` effect uses `number` widgets for angle, speed, and flame count, and the `colorStops` widget to define its color gradient.
+
 
 Utilities for RGB conversions live in `utils.mjs`.
 
 Each widget marks its primary input with `data-key` so the host can sync values without re-rendering.
+

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -31,7 +31,7 @@
           <option>gradient</option>
           <option>solid</option>
           <option>fire</option>
-          <option>fireShader</option>
+          <option>fireCss</option>
         </select>
       </label>
     </div>

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -9,6 +9,6 @@ Browser interface providing live preview and controls.
 - `controls/` – reusable widgets and `renderControls` helper.
 - `renderer.mjs` – scene generation and drawing. The preview dims non-pixel areas while showing LED samples in fully saturated, bright colors for clearer contrast.
 
-The UI now includes a `fireShader` effect with adjustable speed, angle, flame height, and color gradient.
+The UI now includes a `fireCss` effect with adjustable rotation, color gradient, and number of flames.
 
 `ui-controls.mjs` now interacts with namespaced params (`effects` and `post`).

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -9,6 +9,6 @@ Browser interface providing live preview and controls.
 - `controls/` – reusable widgets and `renderControls` helper.
 - `renderer.mjs` – scene generation and drawing. The preview dims non-pixel areas while showing LED samples in fully saturated, bright colors for clearer contrast.
 
-The UI now includes a `fireCss` effect with adjustable rotation, color gradient, and number of flames.
+The UI now includes a `fireCss` effect with adjustable rotation, color gradient, number of flames, and speed control.
 
 `ui-controls.mjs` now interacts with namespaced params (`effects` and `post`).

--- a/src/ui/ui-controls.mjs
+++ b/src/ui/ui-controls.mjs
@@ -114,7 +114,7 @@ export function initUI(win, doc, P, send, onToggleFreeze){
     if (e.key === '1') effect.value = 'gradient', effect.onchange();
     if (e.key === '2') effect.value = 'solid', effect.onchange();
     if (e.key === '3') effect.value = 'fire', effect.onchange();
-    if (e.key === '4') effect.value = 'fireShader', effect.onchange();
+    if (e.key === '4') effect.value = 'fireCss', effect.onchange();
     if (e.key.toLowerCase() === 'b') send({ brightness: 0 });
     if (e.key === ' ') onToggleFreeze();
   });


### PR DESCRIPTION
## Summary
- replace shader-based fire effect with CSS-inspired implementation
- add rotation, color gradient, and flame count controls
- update UI and docs for new fireCss effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad1378e0288322bc3c1bab84d44969