### PR TITLE
Run engine via bin script and update tests

### DIFF
--- a/bin/engine.mjs
+++ b/bin/engine.mjs
@@ -1,0 +1,3 @@
+import { start } from "../src/engine.mjs";
+
+start();

--- a/bin/readme.md
+++ b/bin/readme.md
@@ -1,0 +1,5 @@
+# Bin scripts
+
+Command-line entry points for BarnLights Playbox.
+
+- `engine.mjs` – imports `start` from `src/engine.mjs` and begins emitting SLICES_NDJSON frames.

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,8 @@ Minimal Node + browser setup that:
 - serves a **live preview** with a light barn perspective and per-LED colored dots.
 
 ## Architecture
-- `src/engine.mjs` renders frames and streams NDJSON.
+- `bin/engine.mjs` invokes the engine's `start` function and streams NDJSON frames.
+- `src/engine.mjs` renders frames and exposes live parameters.
 - `src/server.mjs` serves the UI and relays WebSocket param updates.
 - `src/ui/` contains the browser preview and controls.
 

--- a/src/engine.mjs
+++ b/src/engine.mjs
@@ -114,9 +114,7 @@ function buildSlicesFrame(frame, fps){
 }
 
 // ------- main loop -------
-let last = process.hrtime.bigint();
-let acc = 0;
-let frame = 0;
+let last, acc, frame;
 
 function tick(){
   const now = process.hrtime.bigint();
@@ -145,7 +143,9 @@ function tick(){
   setImmediate(tick);
 }
 
-// Only tick if we are running as the main process to prevent output swamping tests
-if (import.meta.url === url.pathToFileURL(process.argv[1]).href) {
+export function start(){
+  last = process.hrtime.bigint();
+  acc = 0;
+  frame = 0;
   tick();
 }

--- a/src/readme.md
+++ b/src/readme.md
@@ -2,7 +2,7 @@
 
 Core runtime code for BarnLights Playbox:
 
-- `engine.mjs` – render loop emitting SLICES_NDJSON and exposing live `params`.
+- `engine.mjs` – side‑effect‑free render loop exposing `params`; call `start()` to emit SLICES_NDJSON.
 - `server.mjs` – HTTP/WebSocket server serving the UI and applying param updates.
 - `effects/` – effect implementations, registry and post-processing helpers.
 - `ui/` – browser UI for preview and controls, can modify the `params` which the engine renders.

--- a/test/engine.test.mjs
+++ b/test/engine.test.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'url';
 const ROOT = fileURLToPath(new URL('..', import.meta.url));
 
 async function getFrame(){
-  const proc = spawn('node', ['src/engine.mjs'], { cwd: ROOT });
+  const proc = spawn('node', ['bin/engine.mjs'], { cwd: ROOT });
   const rl = createInterface({ input: proc.stdout });
   let jsonLine = null;
   for await (const line of rl) {

--- a/test/readme.md
+++ b/test/readme.md
@@ -7,6 +7,6 @@ Automated checks for BarnLights Playbox:
 - `config.test.mjs` – verifies configuration LED totals and section bounds.
 - `web.test.mjs` – loads the browser preview and fails on console errors.
 
-The engine module only starts emitting frames when run directly, keeping test output clean.
+The engine exports a `start` function and is invoked via `bin/engine.mjs` so imports remain side‑effect free during tests.
 
 Run with `npm test`.


### PR DESCRIPTION
## Summary
- export `start()` from `src/engine.mjs` and remove direct execution
- add `bin/engine.mjs` wrapper to launch the engine
- update tests and docs to call the new bin script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad171030188322a201ccc6a4b47fa0