### PR TITLE
feat: add wall mode parameter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,9 @@ Minimal Node + browser setup that:
 
 Runtime parameters are grouped under `effects` for effect-specific settings
 and `post` for modifiers like brightness, tint and strobe which can be applied ontop.
+The top-level `wallMode` parameter chooses whether both walls share the same
+rendering (`duplicate`), render independently (`independent`), or act as a
+single wide scene spanning both sides (`extend`).
 
 ## Quick start
 1. Open your terminal

--- a/src/effects/readme.md
+++ b/src/effects/readme.md
@@ -8,5 +8,10 @@ Effect modules and utilities for the renderer.
 - `post.mjs` – post-processing pipeline and modifier registration.
 
 
-Each effect contains its own render function and declares its modifiable parameters. 
+Each effect contains its own render function and declares its modifiable parameters.
 Modifiers, or "post" effects, are commonly available to be applied on top of any plugin effect.
+
+Effects receive a `side` argument of `"left"`, `"right"` or `"both"` along with the
+scene dimensions. When `wallMode` is set to `"extend"`, the engine calls an
+effect's render function once with a width of `SCENE_W*2` and `side` set to
+`"both"`. Use this to span visuals seamlessly across the two walls.

--- a/src/engine.mjs
+++ b/src/engine.mjs
@@ -19,7 +19,7 @@ export const SCENE_W = 512, SCENE_H = 128; // virtual canvas per side
 export const params = {
   fpsCap: 60,
   effect: "gradient",        // "gradient" | "solid" | "fire"
-  mirrorWalls: true,
+  wallMode: "duplicate",     // "duplicate" | "independent" | "extend"
   effects: {},
   post: {
     brightness: 0.8,
@@ -56,7 +56,7 @@ for (const eff of Object.values(effects)) {
 
 export function updateParams(patch){
   for (const [key, value] of Object.entries(patch)) {
-    if (key === "fpsCap" || key === "effect" || key === "mirrorWalls") {
+    if (key === "fpsCap" || key === "effect" || key === "wallMode") {
       params[key] = value;
     } else if (postKeys.has(key)) {
       params.post[key] = value;
@@ -73,6 +73,7 @@ export function updateParams(patch){
 // ------- engine buffers -------
 const leftF  = new Float32Array(SCENE_W*SCENE_H*3);
 const rightF = new Float32Array(SCENE_W*SCENE_H*3);
+const bothF  = new Float32Array(SCENE_W*SCENE_H*3*2);
 
 // ------- scene render -------
 function renderSceneForSide(side, t){
@@ -88,6 +89,19 @@ function renderSceneForSide(side, t){
   for (const fn of postPipeline) {
     fn(target, t, post, SCENE_W, SCENE_H);
   }
+}
+
+function renderSceneExtended(t){
+  const effect = effects[params.effect] || effects["gradient"];
+  const effectParams = params.effects[effect.id] || {};
+  effect.render(bothF, SCENE_W*2, SCENE_H, t, effectParams, "both");
+  const post = params.post;
+  for (const fn of postPipeline) {
+    fn(bothF, t, post, SCENE_W*2, SCENE_H);
+  }
+  const half = SCENE_W*SCENE_H*3;
+  leftF.set(bothF.subarray(0, half));
+  rightF.set(bothF.subarray(half));
 }
 
 // ------- build slices frame -------
@@ -133,9 +147,13 @@ function tick(){
     acc = 0;
 
     // Stage A+B for left/right
-    renderSceneForSide("left", t);
-    if (params.mirrorWalls) rightF.set(leftF);
-    else renderSceneForSide("right", t);
+    if (params.wallMode === "extend") {
+      renderSceneExtended(t);
+    } else {
+      renderSceneForSide("left", t);
+      if (params.wallMode === "duplicate") rightF.set(leftF);
+      else renderSceneForSide("right", t);
+    }
 
     // Emit SLICES_NDJSON to stdout
     const out = buildSlicesFrame(frame++, cap);

--- a/src/readme.md
+++ b/src/readme.md
@@ -2,7 +2,7 @@
 
 Core runtime code for BarnLights Playbox:
 
-- `engine.mjs` – render loop emitting SLICES_NDJSON and exposing live `params`.
+- `engine.mjs` – render loop emitting SLICES_NDJSON and exposing live `params` such as `wallMode` (`duplicate` | `independent` | `extend`) for left/right rendering.
 - `server.mjs` – HTTP/WebSocket server serving the UI and applying param updates.
 - `effects/` – effect implementations, registry and post-processing helpers.
 - `ui/` – browser UI for preview and controls, can modify the `params` which the engine renders.

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -45,7 +45,13 @@
       <label>Gamma <input id="gamma" type="range" min="0.5" max="3" step="0.01"><span id="gamma_v"></span><small class="desc">brightness curve</small></label>
       <label>Roll px <input id="rollPx" type="range" min="0" max="512" step="1"><span id="rollPx_v"></span><small class="desc">shift pattern</small></label>
       <label>FPS cap <input id="fpsCap" type="range" min="1" max="60" step="1"><span id="fpsCap_v"></span></label>
-      <label>Mirror walls <input id="mirrorWalls" type="checkbox"></label>
+      <label>Wall mode
+        <select id="wallMode">
+          <option value="duplicate">Duplicate</option>
+          <option value="independent">Independent</option>
+          <option value="extend">Extend</option>
+        </select>
+      </label>
     </div>
   </fieldset>
 

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -5,7 +5,7 @@ Browser interface providing live preview and controls.
 - `index.html` – control layout and canvas elements grouped into Effect, General, Strobe and Tint sections.
 - `main.mjs` – entry point for JS logic, wiring modules together, exposes a 'run' function.
 - `connection.mjs` – WebSocket setup and message handling.
-- `ui-controls.mjs` – wires DOM controls to params and renders effect-specific widgets.
+- `ui-controls.mjs` – wires DOM controls to params and renders effect-specific widgets, including a wall mode selector (`duplicate`, `independent`, `extend`).
 - `controls/` – reusable widgets and `renderControls` helper.
 - `renderer.mjs` – scene generation and drawing. The preview dims non-pixel areas while showing LED samples in fully saturated, bright colors for clearer contrast.
 

--- a/src/ui/renderer.mjs
+++ b/src/ui/renderer.mjs
@@ -6,6 +6,7 @@ export { registerPostModifier };
 
 let offscreen = null, offCtx = null;
 let freeze = false;
+let bothF = null;
 
 function fullBrightRGB(r, g, b){
   const min = Math.min(r, g, b);
@@ -90,8 +91,16 @@ function drawSections(ctx, sceneF32, layout, sceneW, sceneH){
 
 export function frame(win, doc, ctxL, ctxR, leftF, rightF, P, layoutLeft, layoutRight, sceneW, sceneH){
   const t = freeze ? 0 : win.performance.now() / 1000;
-  renderScene(leftF, "left", t, P, sceneW, sceneH);
-  if (P.mirrorWalls) rightF.set(leftF); else renderScene(rightF, "right", t, P, sceneW, sceneH);
+  if (P.wallMode === "extend") {
+    const len = leftF.length;
+    if (!bothF || bothF.length !== len * 2) bothF = new Float32Array(len * 2);
+    renderScene(bothF, "both", t, P, sceneW * 2, sceneH);
+    leftF.set(bothF.subarray(0, len));
+    rightF.set(bothF.subarray(len));
+  } else {
+    renderScene(leftF, "left", t, P, sceneW, sceneH);
+    if (P.wallMode === "duplicate") rightF.set(leftF); else renderScene(rightF, "right", t, P, sceneW, sceneH);
+  }
   drawScene(ctxL, leftF, sceneW, sceneH, win, doc);
   if (layoutLeft)  drawSections(ctxL, leftF, layoutLeft, sceneW, sceneH);
   drawScene(ctxR, rightF, sceneW, sceneH, win, doc);

--- a/src/ui/ui-controls.mjs
+++ b/src/ui/ui-controls.mjs
@@ -34,8 +34,8 @@ function applyTop(doc, P){
   const fps = doc.getElementById('fpsCap');
   const fpsV = doc.getElementById('fpsCap_v');
   if (fps){ fps.value = P.fpsCap; if (fpsV) fpsV.textContent = P.fpsCap; }
-  const mirror = doc.getElementById('mirrorWalls');
-  if (mirror) mirror.checked = !!P.mirrorWalls;
+  const wallMode = doc.getElementById('wallMode');
+  if (wallMode) wallMode.value = P.wallMode;
 }
 
 function applyPost(doc, P){
@@ -77,10 +77,10 @@ export function initUI(win, doc, P, send, onToggleFreeze){
     if (fpsV) fpsV.textContent = P.fpsCap;
     fps.oninput = () => { const v = parseFloat(fps.value); P.fpsCap = v; if (fpsV) fpsV.textContent = v; send({ fpsCap: v }); };
   }
-  const mirror = doc.getElementById('mirrorWalls');
-  if (mirror){
-    mirror.checked = !!P.mirrorWalls;
-    mirror.oninput = () => { P.mirrorWalls = mirror.checked; send({ mirrorWalls: mirror.checked }); };
+  const wallMode = doc.getElementById('wallMode');
+  if (wallMode){
+    wallMode.value = P.wallMode;
+    wallMode.onchange = () => { P.wallMode = wallMode.value; send({ wallMode: wallMode.value }); };
   }
   for (const [key,val] of Object.entries(P.post)){
     if (key === 'tint') continue;


### PR DESCRIPTION
## Summary
- replace boolean `mirrorWalls` with string `wallMode`
- allow wall mode updates from UI and engine
- document new wall mode option
- support `extend` mode to span effects across both walls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad13c550e88322b96402aacf155cb2