### PR TITLE
feat: add draggable color stops to gradient

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # BarnLights Playbox (test harness)
 
 Minimal Node + browser setup that:
-- renders gradients / solid / fire onto a 2D virtual scene per side,
+- renders gradients / solid / fire onto a 2D virtual scene per side, with gradients supporting multiple color stops,
 - applies strobe / brightness / tint / roll / gamma,
 - samples per your layout JSON into per-row "slices",
 - **emits SLICES_NDJSON to stdout** (one line per frame),

--- a/src/effects/library/gradient.mjs
+++ b/src/effects/library/gradient.mjs
@@ -4,22 +4,35 @@ const mix3 = (A,B,t)=> [mix(A[0],B[0],t), mix(A[1],B[1],t), mix(A[2],B[2],t)];
 export const id = 'gradient';
 export const displayName = 'Gradient';
 export const defaultParams = {
-  gradStart: [0.0, 0.0, 1.0],
-  gradEnd:   [1.0, 0.0, 0.0],
+  stops: [
+    { pos: 0, color: [0.0, 0.0, 1.0] },
+    { pos: 1, color: [1.0, 0.0, 0.0] },
+  ],
   gradPhase: 0.0,
 };
 export const paramSchema = {
-  gradStart: { type: 'color' },
-  gradEnd:   { type: 'color' },
+  stops: { type: 'colorStops', label: 'Stops' },
   gradPhase: { type: 'number', min: 0, max: 1, step: 0.001 },
 };
 
+function sampleGradient(stops, u){
+  const sorted = stops.slice().sort((a,b)=> (a.pos ?? 0) - (b.pos ?? 0));
+  let i = 1;
+  while (i < sorted.length && u >= sorted[i].pos) i++;
+  const left = sorted[i-1];
+  const right = sorted[i] || { pos: sorted[0].pos + 1, color: sorted[0].color };
+  const span = right.pos - left.pos;
+  const t = span > 0 ? (u - left.pos) / span : 0;
+  return mix3(left.color, right.color, t);
+}
+
 export function render(sceneF32, W, H, t, params){
-  const { gradStart, gradEnd, gradPhase=0 } = params;
+  const { stops = [], gradPhase = 0 } = params;
+  if (stops.length < 2) return;
   for(let y=0;y<H;y++){
     for(let x=0;x<W;x++){
       const u = (x/W + gradPhase) % 1;
-      const rgb = mix3(gradStart, gradEnd, u);
+      const rgb = sampleGradient(stops, u);
       const i=(y*W+x)*3;
       sceneF32[i]=rgb[0]; sceneF32[i+1]=rgb[1]; sceneF32[i+2]=rgb[2];
     }

--- a/src/effects/library/readme.md
+++ b/src/effects/library/readme.md
@@ -5,3 +5,4 @@ One file per visual effect. Each module exports the following:
 Note that this includes its own render function, and parameters for modification.
 
 Available effects include `gradient`, `solid`, `fire`, and the shader-based `fireShader`.
+The `gradient` effect now supports arbitrary color stops for flexible palettes.

--- a/src/ui/controls/colorStops.mjs
+++ b/src/ui/controls/colorStops.mjs
@@ -9,6 +9,18 @@ export function colorStopsWidget(key, schema, values, send){
   container.style.gap = '4px';
   label.appendChild(container);
 
+  const bar = document.createElement('div');
+  bar.style.position = 'relative';
+  bar.style.height = '24px';
+  bar.style.border = '1px solid #ccc';
+  container.appendChild(bar);
+
+  const list = document.createElement('div');
+  list.style.display = 'flex';
+  list.style.flexDirection = 'column';
+  list.style.gap = '4px';
+  container.appendChild(list);
+
   const stops = values[key] || [];
   values[key] = stops;
 
@@ -17,8 +29,41 @@ export function colorStopsWidget(key, schema, values, send){
   }
 
   function render(){
-    container.innerHTML = '';
+    bar.innerHTML = '';
+    list.innerHTML = '';
+
+    const grad = stops.map(s=>`${rgbToHex(s.color || [1,1,1])} ${(s.pos ?? 0)*100}%`).join(',');
+    bar.style.background = `linear-gradient(to right, ${grad})`;
+
     stops.forEach((stop,i)=>{
+      const handle = document.createElement('div');
+      handle.style.position = 'absolute';
+      handle.style.left = `${(stop.pos ?? 0)*100}%`;
+      handle.style.top = '0';
+      handle.style.width = '12px';
+      handle.style.height = '100%';
+      handle.style.transform = 'translateX(-50%)';
+      handle.style.background = rgbToHex(stop.color || [1,1,1]);
+      handle.style.cursor = 'pointer';
+
+      handle.onmousedown = (e) => {
+        e.preventDefault();
+        const onMove = (ev) => {
+          const rect = bar.getBoundingClientRect();
+          let p = (ev.clientX - rect.left) / rect.width;
+          p = Math.min(Math.max(p,0),1);
+          stop.pos = p;
+          emit();
+          render();
+        };
+        const onUp = () => {
+          document.removeEventListener('mousemove', onMove);
+          document.removeEventListener('mouseup', onUp);
+        };
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', onUp);
+      };
+
       const row = document.createElement('div');
       row.style.display = 'flex';
       row.style.alignItems = 'center';
@@ -27,24 +72,28 @@ export function colorStopsWidget(key, schema, values, send){
       const pos = document.createElement('input');
       pos.type = 'number'; pos.min = 0; pos.max = 1; pos.step = 0.01;
       pos.value = stop.pos ?? 0;
-      pos.oninput = () => { stop.pos = parseFloat(pos.value); emit(); };
+      pos.oninput = () => { stop.pos = parseFloat(pos.value); emit(); render(); };
 
       const col = document.createElement('input');
       col.type = 'color';
       col.value = rgbToHex(stop.color || [1,1,1]);
-      col.oninput = () => { stop.color = hexToRgb(col.value); emit(); };
+      col.oninput = () => { stop.color = hexToRgb(col.value); emit(); render(); };
+
+      handle.onclick = () => col.click();
 
       const del = document.createElement('button');
       del.type = 'button'; del.textContent = 'x';
       del.onclick = () => { stops.splice(i,1); emit(); render(); };
 
       row.append(pos, col, del);
-      container.appendChild(row);
+      list.appendChild(row);
+      bar.appendChild(handle);
     });
+
     const add = document.createElement('button');
     add.type = 'button'; add.textContent = 'Add';
-    add.onclick = () => { stops.push({ pos: 0, color: [1,1,1] }); emit(); render(); };
-    container.appendChild(add);
+    add.onclick = () => { stops.push({ pos: 0.5, color: [1,1,1] }); emit(); render(); };
+    list.appendChild(add);
   }
 
   render();

--- a/src/ui/controls/readme.md
+++ b/src/ui/controls/readme.md
@@ -7,9 +7,9 @@ Dynamic UI widgets for effect parameters.
 - `checkbox.mjs` – boolean toggle.
 - `enum.mjs` – dropdown selector.
 - `color.mjs` – RGB color picker.
-- `colorStops.mjs` – editable list of color/position pairs.
+- `colorStops.mjs` – draggable gradient editor for color/position pairs.
 
-The `fireShader` effect uses the `colorStops` widget to define its color gradient.
+The `fireShader` and `gradient` effects use the `colorStops` widget to define their color palettes.
 
 Utilities for RGB conversions live in `utils.mjs`.
 

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -9,6 +9,6 @@ Browser interface providing live preview and controls.
 - `controls/` – reusable widgets and `renderControls` helper.
 - `renderer.mjs` – scene generation and drawing. The preview dims non-pixel areas while showing LED samples in fully saturated, bright colors for clearer contrast.
 
-The UI now includes a `fireShader` effect with adjustable speed, angle, flame height, and color gradient.
+The UI now includes a `fireShader` effect with adjustable speed, angle, flame height, and color gradient. The `gradient` effect exposes draggable color stops for custom palettes.
 
 `ui-controls.mjs` now interacts with namespaced params (`effects` and `post`).


### PR DESCRIPTION
## Summary
- allow gradient effect to render from configurable color stops
- add draggable color stop widget in UI controls
- document gradient stop support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad34670be48322acde9389d33d5ec3