### PR TITLE
Remove wall mode and duplicate scene across both walls

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # BarnLights Playbox (test harness)
 
 Minimal Node + browser setup that:
-- renders gradients / solid / fire onto a 2D virtual scene per side,
+- renders gradients / solid / fire onto a 2D virtual scene duplicated to both walls,
 - applies strobe / brightness / tint / roll / gamma,
 - samples per your layout JSON into per-row "slices",
 - **emits SLICES_NDJSON to stdout** (one line per frame),
@@ -14,10 +14,8 @@ Minimal Node + browser setup that:
 - `src/ui/` contains the browser preview and controls.
 
 Runtime parameters are grouped under `effects` for effect-specific settings
-and `post` for modifiers like brightness, tint and strobe which can be applied ontop.
-The top-level `wallMode` parameter chooses whether both walls share the same
-rendering (`duplicate`), render independently (`independent`), or act as a
-single wide scene spanning both sides (`extend`).
+and `post` for modifiers like brightness, tint and strobe which can be applied on top.
+A single scene is rendered each frame and copied to both walls.
 
 ## Quick start
 1. Open your terminal

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,12 @@ Runtime parameters are grouped under `effects` for effect-specific settings
 and `post` for modifiers like brightness, tint and strobe which can be applied on top.
 A single scene is rendered each frame and copied to both walls.
 
+## Frame pipeline
+1. The engine renders the active effect into a floating point RGB buffer (`leftFrame`).
+2. Post-processing modifiers run on that buffer and the result is duplicated to `rightFrame`.
+3. Each frame is sliced according to the configured layouts and emitted as base64-encoded `rgb8` NDJSON.
+4. The browser preview reuses these frame buffers to draw the scene and per-LED indicators.
+
 ## Quick start
 1. Open your terminal
 2. Navigate to this directory

--- a/src/effects/library/solid.mjs
+++ b/src/effects/library/solid.mjs
@@ -1,17 +1,17 @@
 export const id = 'solid';
 export const displayName = 'Solid';
 export const defaultParams = {
-  solidLeft:  [0.0, 1.0, 0.0],
-  solidRight: [1.0, 1.0, 1.0],
+  solidColor: [0.0, 1.0, 0.0],
 };
 export const paramSchema = {
-  solidLeft:  { type: 'color' },
-  solidRight: { type: 'color' },
+  solidColor: { type: 'color' },
 };
 
-export function render(sceneF32, W, H, t, params, side){
-  const rgb = side === 'left' ? params.solidLeft : params.solidRight;
-  for(let i=0;i<sceneF32.length;i+=3){
-    sceneF32[i]=rgb[0]; sceneF32[i+1]=rgb[1]; sceneF32[i+2]=rgb[2];
+export function render(sceneF32, W, H, t, params){
+  const rgb = params.solidColor;
+  for (let i = 0; i < sceneF32.length; i += 3) {
+    sceneF32[i] = rgb[0];
+    sceneF32[i + 1] = rgb[1];
+    sceneF32[i + 2] = rgb[2];
   }
 }

--- a/src/effects/readme.md
+++ b/src/effects/readme.md
@@ -10,8 +10,5 @@ Effect modules and utilities for the renderer.
 
 Each effect contains its own render function and declares its modifiable parameters.
 Modifiers, or "post" effects, are commonly available to be applied on top of any plugin effect.
-
-Effects receive a `side` argument of `"left"`, `"right"` or `"both"` along with the
-scene dimensions. When `wallMode` is set to `"extend"`, the engine calls an
-effect's render function once with a width of `SCENE_W*2` and `side` set to
-`"both"`. Use this to span visuals seamlessly across the two walls.
+Effects render into a single virtual scene using the signature
+`(sceneF32, W, H, t, params)`. The engine copies this scene to both walls.

--- a/src/engine.mjs
+++ b/src/engine.mjs
@@ -19,7 +19,6 @@ export const SCENE_W = 512, SCENE_H = 128; // virtual canvas per side
 export const params = {
   fpsCap: 60,
   effect: "gradient",        // "gradient" | "solid" | "fire"
-  wallMode: "duplicate",     // "duplicate" | "independent" | "extend"
   effects: {},
   post: {
     brightness: 0.8,
@@ -56,7 +55,7 @@ for (const eff of Object.values(effects)) {
 
 export function updateParams(patch){
   for (const [key, value] of Object.entries(patch)) {
-    if (key === "fpsCap" || key === "effect" || key === "wallMode") {
+    if (key === "fpsCap" || key === "effect") {
       params[key] = value;
     } else if (postKeys.has(key)) {
       params.post[key] = value;
@@ -71,37 +70,21 @@ export function updateParams(patch){
 }
 
 // ------- engine buffers -------
-const leftF  = new Float32Array(SCENE_W*SCENE_H*3);
-const rightF = new Float32Array(SCENE_W*SCENE_H*3);
-const bothF  = new Float32Array(SCENE_W*SCENE_H*3*2);
+const leftF  = new Float32Array(SCENE_W * SCENE_H * 3);
+const rightF = new Float32Array(SCENE_W * SCENE_H * 3);
 
 // ------- scene render -------
-function renderSceneForSide(side, t){
-  const target = side==="left" ? leftF : rightF;
-
-  // Stage A
+function renderScene(t) {
   const effect = effects[params.effect] || effects["gradient"];
   const effectParams = params.effects[effect.id] || {};
-  effect.render(target, SCENE_W, SCENE_H, t, effectParams, side);
+  effect.render(leftF, SCENE_W, SCENE_H, t, effectParams);
 
-  // Stage B
   const post = params.post;
   for (const fn of postPipeline) {
-    fn(target, t, post, SCENE_W, SCENE_H);
+    fn(leftF, t, post, SCENE_W, SCENE_H);
   }
-}
 
-function renderSceneExtended(t){
-  const effect = effects[params.effect] || effects["gradient"];
-  const effectParams = params.effects[effect.id] || {};
-  effect.render(bothF, SCENE_W*2, SCENE_H, t, effectParams, "both");
-  const post = params.post;
-  for (const fn of postPipeline) {
-    fn(bothF, t, post, SCENE_W*2, SCENE_H);
-  }
-  const half = SCENE_W*SCENE_H*3;
-  leftF.set(bothF.subarray(0, half));
-  rightF.set(bothF.subarray(half));
+  rightF.set(leftF);
 }
 
 // ------- build slices frame -------
@@ -144,14 +127,8 @@ function tick(){
     const t = Number(now)/1e9;
     acc = 0;
 
-    // Stage A+B for left/right
-    if (params.wallMode === "extend") {
-      renderSceneExtended(t);
-    } else {
-      renderSceneForSide("left", t);
-      if (params.wallMode === "duplicate") rightF.set(leftF);
-      else renderSceneForSide("right", t);
-    }
+    // Render scene and duplicate
+    renderScene(t);
 
     // Emit SLICES_NDJSON to stdout
     const out = buildSlicesFrame(frame++, cap);

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -45,13 +45,6 @@
       <label>Gamma <input id="gamma" type="range" min="0.5" max="3" step="0.01"><span id="gamma_v"></span><small class="desc">brightness curve</small></label>
       <label>Roll px <input id="rollPx" type="range" min="0" max="512" step="1"><span id="rollPx_v"></span><small class="desc">shift pattern</small></label>
       <label>FPS cap <input id="fpsCap" type="range" min="1" max="60" step="1"><span id="fpsCap_v"></span></label>
-      <label>Wall mode
-        <select id="wallMode">
-          <option value="duplicate">Duplicate</option>
-          <option value="independent">Independent</option>
-          <option value="extend">Extend</option>
-        </select>
-      </label>
     </div>
   </fieldset>
 

--- a/src/ui/main.mjs
+++ b/src/ui/main.mjs
@@ -38,10 +38,10 @@ export async function run(docArg = globalThis.document){
       Object.assign(params, m.params);
       const sceneW = m.scene.w;
       const sceneH = m.scene.h;
-      const leftF  = new Float32Array(sceneW * sceneH * 3);
-      const rightF = new Float32Array(sceneW * sceneH * 3);
+      const leftFrame  = new Float32Array(sceneW * sceneH * 3);
+      const rightFrame = new Float32Array(sceneW * sceneH * 3);
       initUI(win, doc, params, send, toggleFreeze);
-      if (ctxL && ctxR) frame(win, doc, ctxL, ctxR, leftF, rightF, params, layoutLeft, layoutRight, sceneW, sceneH);
+      if (ctxL && ctxR) frame(win, doc, ctxL, ctxR, leftFrame, rightFrame, params, layoutLeft, layoutRight, sceneW, sceneH);
       else setStatus(doc, "Preview unavailable");
     },
     (m) => {

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -5,9 +5,9 @@ Browser interface providing live preview and controls.
 - `index.html` – control layout and canvas elements grouped into Effect, General, Strobe and Tint sections.
 - `main.mjs` – entry point for JS logic, wiring modules together, exposes a 'run' function.
 - `connection.mjs` – WebSocket setup and message handling.
-- `ui-controls.mjs` – wires DOM controls to params and renders effect-specific widgets, including a wall mode selector (`duplicate`, `independent`, `extend`).
+- `ui-controls.mjs` – wires DOM controls to params and renders effect-specific widgets.
 - `controls/` – reusable widgets and `renderControls` helper.
-- `renderer.mjs` – scene generation and drawing. The preview dims non-pixel areas while showing LED samples in fully saturated, bright colors for clearer contrast.
+- `renderer.mjs` – scene generation and drawing, duplicating a single scene to both canvases. The preview dims non-pixel areas while showing LED samples in fully saturated, bright colors for clearer contrast.
 
 The UI now includes a `fireShader` effect with adjustable speed, angle, flame height, and color gradient.
 

--- a/src/ui/renderer.mjs
+++ b/src/ui/renderer.mjs
@@ -27,6 +27,7 @@ export function toggleFreeze(){
   freeze = !freeze;
 }
 
+// renderScene: draw the active effect into a buffer and apply post-processing
 export function renderScene(target, t, P, sceneW, sceneH) {
   const effect = effects[P.effect] || effects["gradient"];
   const effectParams = P.effects[effect.id] || {};
@@ -88,13 +89,14 @@ function drawSections(ctx, sceneF32, layout, sceneW, sceneH){
   });
 }
 
-export function frame(win, doc, ctxL, ctxR, leftF, rightF, P, layoutLeft, layoutRight, sceneW, sceneH) {
+// frame: render once, draw to both previews, then schedule the next loop
+export function frame(win, doc, ctxL, ctxR, leftFrame, rightFrame, P, layoutLeft, layoutRight, sceneW, sceneH) {
   const t = freeze ? 0 : win.performance.now() / 1000;
-  renderScene(leftF, t, P, sceneW, sceneH);
-  rightF.set(leftF);
-  drawScene(ctxL, leftF, sceneW, sceneH, win, doc);
-  if (layoutLeft) drawSections(ctxL, leftF, layoutLeft, sceneW, sceneH);
-  drawScene(ctxR, rightF, sceneW, sceneH, win, doc);
-  if (layoutRight) drawSections(ctxR, rightF, layoutRight, sceneW, sceneH);
-  win.requestAnimationFrame(() => frame(win, doc, ctxL, ctxR, leftF, rightF, P, layoutLeft, layoutRight, sceneW, sceneH));
+  renderScene(leftFrame, t, P, sceneW, sceneH);
+  rightFrame.set(leftFrame);
+  drawScene(ctxL, leftFrame, sceneW, sceneH, win, doc);
+  if (layoutLeft) drawSections(ctxL, leftFrame, layoutLeft, sceneW, sceneH);
+  drawScene(ctxR, rightFrame, sceneW, sceneH, win, doc);
+  if (layoutRight) drawSections(ctxR, rightFrame, layoutRight, sceneW, sceneH);
+  win.requestAnimationFrame(() => frame(win, doc, ctxL, ctxR, leftFrame, rightFrame, P, layoutLeft, layoutRight, sceneW, sceneH));
 }

--- a/src/ui/ui-controls.mjs
+++ b/src/ui/ui-controls.mjs
@@ -33,9 +33,10 @@ function renderEffectControls(doc, P){
 function applyTop(doc, P){
   const fps = doc.getElementById('fpsCap');
   const fpsV = doc.getElementById('fpsCap_v');
-  if (fps){ fps.value = P.fpsCap; if (fpsV) fpsV.textContent = P.fpsCap; }
-  const wallMode = doc.getElementById('wallMode');
-  if (wallMode) wallMode.value = P.wallMode;
+  if (fps) {
+    fps.value = P.fpsCap;
+    if (fpsV) fpsV.textContent = P.fpsCap;
+  }
 }
 
 function applyPost(doc, P){
@@ -72,15 +73,15 @@ export function initUI(win, doc, P, send, onToggleFreeze){
 
   const fps = doc.getElementById('fpsCap');
   const fpsV = doc.getElementById('fpsCap_v');
-  if (fps){
+  if (fps) {
     fps.value = P.fpsCap;
     if (fpsV) fpsV.textContent = P.fpsCap;
-    fps.oninput = () => { const v = parseFloat(fps.value); P.fpsCap = v; if (fpsV) fpsV.textContent = v; send({ fpsCap: v }); };
-  }
-  const wallMode = doc.getElementById('wallMode');
-  if (wallMode){
-    wallMode.value = P.wallMode;
-    wallMode.onchange = () => { P.wallMode = wallMode.value; send({ wallMode: wallMode.value }); };
+    fps.oninput = () => {
+      const v = parseFloat(fps.value);
+      P.fpsCap = v;
+      if (fpsV) fpsV.textContent = v;
+      send({ fpsCap: v });
+    };
   }
   for (const [key,val] of Object.entries(P.post)){
     if (key === 'tint') continue;


### PR DESCRIPTION
## Summary
- remove wall mode parameter and always render a single scene duplicated to both walls
- drop side-specific solid effect parameters in favor of a single `solidColor`
- simplify UI controls and renderer for the new duplication behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad3af153048322aafd703a163126b5