### PR TITLE
Add wrap-aware bilinear sampler

### DIFF
--- a/src/effects/readme.md
+++ b/src/effects/readme.md
@@ -4,12 +4,19 @@ Effect modules and utilities for the renderer.
 
 - `library/` – individual effect implementations (e.g. gradient, solid, fire, fireShader).
 - `index.mjs` – aggregates the library into an `effects` map keyed by id.
-- `modifiers.mjs` – shared modifiers and sampling helpers.
+- `modifiers.mjs` – shared modifiers and sampling helpers. Includes
+  `bilinearSampleRGB` for clamped edges and `bilinearSampleWrapRGB` for
+  wrapping coordinates used by `transformScene`.
 - `post.mjs` – post-processing pipeline and modifier registration.
 
 
 Each effect contains its own render function and declares its modifiable parameters.
 Modifiers, or "post" effects, are commonly available to be applied on top of any plugin effect.
+
+`bilinearSampleWrapRGB` wraps sample coordinates so textures repeat instead of
+clamping at the scene edges. `transformScene` uses this wrapped sampling for
+seamless rotations, while `sliceSection` keeps the clamped `bilinearSampleRGB`
+for layout extraction.
 
 Effects receive a `side` argument of `"left"`, `"right"` or `"both"` along with the
 scene dimensions. When `wallMode` is set to `"extend"`, the engine calls an

--- a/test/effects-sampling.test.mjs
+++ b/test/effects-sampling.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'assert/strict';
-import { bilinearSampleRGB, sliceSection } from '../src/effects/modifiers.mjs';
+import { bilinearSampleRGB, bilinearSampleWrapRGB, sliceSection } from '../src/effects/modifiers.mjs';
 
 // helper to compare arrays with numbers precisely
 const eq = (a, b) => assert.deepEqual(a.map(n => +n.toFixed(5)), b.map(n => +n.toFixed(5)));
@@ -27,6 +27,12 @@ test('bilinearSampleRGB corners and midpoints', () => {
   eq(bilinearSampleRGB(sceneF32, W, H, 1, 0.5), [0.5, 1, 0.5]);
   eq(bilinearSampleRGB(sceneF32, W, H, 0.5, 1), [0.5, 0.5, 1]);
   eq(bilinearSampleRGB(sceneF32, W, H, 0.5, 0.5), [0.5, 0.5, 0.5]);
+});
+
+test('bilinearSampleWrapRGB wraps around edges', () => {
+  eq(bilinearSampleWrapRGB(sceneF32, W, H, -1, 0), [0, 1, 0]);
+  eq(bilinearSampleWrapRGB(sceneF32, W, H, 2, 1), [0, 0, 1]);
+  eq(bilinearSampleWrapRGB(sceneF32, W, H, -0.5, 0), [0.5, 0.5, 0]);
 });
 
 test('sliceSection returns expected byte colors', () => {


### PR DESCRIPTION
## Summary
- add `bilinearSampleWrapRGB` for toroidal bilinear sampling
- use wrapped sampler in `transformScene` with coordinate wrapping
- document wrapping behaviour in effects readme and test wrap sampler

## Testing
- `npm test` *(fails: web view loads with no console errors – Expected values to be strictly equal: 4 !== 0)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0376213083228c02f8a70504e09f