### PR TITLE
feat: add preset save and load

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@ Minimal Node + browser setup that:
 - samples per your layout JSON into per-row "slices",
 - **emits SLICES_NDJSON to stdout** (one line per frame),
 - serves a **live preview** with a light barn perspective and per-LED colored dots.
+- allows saving and loading effect presets through the UI.
 
 ## Architecture
 - `bin/engine.mjs` launches the HTTP server and invokes the engine's `start` function, streaming NDJSON frames.

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Minimal Node + browser setup that:
 - samples per your layout JSON into per-row "slices",
 - **emits SLICES_NDJSON to stdout** (one line per frame),
 - serves a **live preview** with a light barn perspective and per-LED colored dots.
-- allows saving and loading effect presets through the UI.
+- allows saving and loading effect presets through the UI with a dropdown of saved presets.
 
 ## Architecture
 - `bin/engine.mjs` launches the HTTP server and invokes the engine's `start` function, streaming NDJSON frames.

--- a/src/config-store.mjs
+++ b/src/config-store.mjs
@@ -1,0 +1,28 @@
+import fs from "fs/promises";
+import path from "path";
+import url from "url";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+const PRESET_DIR = path.join(ROOT, "config", "presets");
+
+export async function listPresets(){
+  try {
+    const files = await fs.readdir(PRESET_DIR);
+    return files.filter(f => f.endsWith('.json')).map(f => f.slice(0, -5));
+  } catch {
+    return [];
+  }
+}
+
+export async function savePreset(name, params){
+  await fs.mkdir(PRESET_DIR, { recursive: true });
+  const p = path.join(PRESET_DIR, `${name}.json`);
+  await fs.writeFile(p, JSON.stringify(params, null, 2), "utf8");
+}
+
+export async function loadPreset(name){
+  const p = path.join(PRESET_DIR, `${name}.json`);
+  const raw = await fs.readFile(p, "utf8");
+  return JSON.parse(raw);
+}

--- a/src/readme.md
+++ b/src/readme.md
@@ -7,6 +7,7 @@ Core runtime code for BarnLights Playbox:
 - `config-store.mjs` – read/write helpers for saving and loading effect presets.
 - `effects/` – effect implementations, registry and post-processing helpers.
 - `ui/` – browser UI for preview and controls, can modify the `params` which the engine renders.
+- `ui/presets.mjs` – helper to fetch preset names and update the UI dropdown.
 
 ## A note on the engine's use of effects
 

--- a/src/readme.md
+++ b/src/readme.md
@@ -4,6 +4,7 @@ Core runtime code for BarnLights Playbox:
 
 - `engine.mjs` – side‑effect‑free render loop exposing `params`; call `start()` to emit SLICES_NDJSON.
 - `server.mjs` – HTTP/WebSocket server serving the UI and applying param updates.
+- `config-store.mjs` – read/write helpers for saving and loading effect presets.
 - `effects/` – effect implementations, registry and post-processing helpers.
 - `ui/` – browser UI for preview and controls, can modify the `params` which the engine renders.
 

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -5,6 +5,7 @@ import path from "path";
 import url from "url";
 
 import { params, updateParams, layoutLeft, layoutRight, SCENE_W, SCENE_H } from "./engine.mjs";
+import { savePreset, loadPreset, listPresets } from "./config-store.mjs";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const UI_DIR = path.join(__dirname, "ui");
@@ -19,7 +20,7 @@ function sendJson(obj, res){
   res.writeHead(200, { "Content-Type": "application/json" }).end(buf);
 }
 
-const server = http.createServer((req, res) => {
+const server = http.createServer(async (req, res) => {
   const u = new URL(req.url, "http://x/");
   if (u.pathname === "/") return streamFile(path.join(UI_DIR, "index.html"), "text/html", res);
   if (u.pathname === "/preview.mjs") return streamFile(path.join(UI_DIR, "preview.mjs"), "text/javascript", res);
@@ -44,6 +45,24 @@ const server = http.createServer((req, res) => {
   }
   if (u.pathname === "/layout/left") return sendJson(layoutLeft, res);
   if (u.pathname === "/layout/right") return sendJson(layoutRight, res);
+  if (u.pathname === "/presets") return sendJson(await listPresets(), res);
+  if (u.pathname.startsWith("/preset/save/")) {
+    const name = u.pathname.slice("/preset/save/".length);
+    await savePreset(name, params);
+    return sendJson({ ok: true }, res);
+  }
+  if (u.pathname.startsWith("/preset/load/")) {
+    const name = u.pathname.slice("/preset/load/".length);
+    try {
+      const loaded = await loadPreset(name);
+      Object.assign(params, loaded);
+      for (const c of wss.clients) if (c.readyState === 1) c.send(JSON.stringify({ type: "params", params }));
+      return sendJson({ ok: true }, res);
+    } catch {
+      res.writeHead(404).end("Not found");
+      return;
+    }
+  }
   res.writeHead(404).end("Not found");
 });
 

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -27,6 +27,7 @@ const server = http.createServer(async (req, res) => {
   if (u.pathname === "/main.mjs") return streamFile(path.join(UI_DIR, "main.mjs"), "text/javascript", res);
   if (u.pathname === "/connection.mjs") return streamFile(path.join(UI_DIR, "connection.mjs"), "text/javascript", res);
   if (u.pathname === "/ui-controls.mjs") return streamFile(path.join(UI_DIR, "ui-controls.mjs"), "text/javascript", res);
+  if (u.pathname === "/presets.mjs") return streamFile(path.join(UI_DIR, "presets.mjs"), "text/javascript", res);
   if (u.pathname === "/renderer.mjs") return streamFile(path.join(UI_DIR, "renderer.mjs"), "text/javascript", res);
   if (u.pathname.startsWith("/controls/")) {
     const p = path.join(UI_DIR, u.pathname.slice(1));

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -46,8 +46,8 @@
   <fieldset>
     <legend>Presets</legend>
     <div class="row">
-      <input id="presetName" list="presetList" placeholder="name">
-      <datalist id="presetList"></datalist>
+      <input id="presetName" placeholder="name">
+      <select id="presetList"></select>
       <button id="savePreset">Save</button>
       <button id="loadPreset">Load</button>
     </div>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -44,6 +44,16 @@
   </fieldset>
 
   <fieldset>
+    <legend>Presets</legend>
+    <div class="row">
+      <input id="presetName" list="presetList" placeholder="name">
+      <datalist id="presetList"></datalist>
+      <button id="savePreset">Save</button>
+      <button id="loadPreset">Load</button>
+    </div>
+  </fieldset>
+
+  <fieldset>
     <legend>General</legend>
     <div class="row">
       <label>Brightness <input id="brightness" type="range" min="0" max="1" step="0.01"><span id="brightness_v"></span></label>

--- a/src/ui/presets.mjs
+++ b/src/ui/presets.mjs
@@ -1,0 +1,20 @@
+export async function fetchPresetNames(win){
+  const res = await win.fetch('/presets');
+  return res.json();
+}
+
+export function populatePresetDropdown(doc, selectEl, names){
+  selectEl.innerHTML = '';
+  names.forEach(n => {
+    const opt = doc.createElement('option');
+    opt.value = n;
+    opt.textContent = n;
+    selectEl.appendChild(opt);
+  });
+}
+
+export async function refreshPresetDropdown(win, doc, selectEl){
+  const names = await fetchPresetNames(win);
+  populatePresetDropdown(doc, selectEl, names);
+  return names;
+}

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -6,6 +6,7 @@ Browser interface providing live preview and controls.
 - `main.mjs` – entry point for JS logic, wiring modules together, exposes a 'run' function.
 - `connection.mjs` – WebSocket setup and message handling.
 - `ui-controls.mjs` – wires DOM controls to params and renders effect-specific widgets.
+- `presets.mjs` – fetches preset names and populates the dropdown list.
 - Preset controls allow saving and loading configuration snapshots.
 - `controls/` – reusable widgets and `renderControls` helper.
 - `renderer.mjs` – scene generation and drawing, duplicating a single scene to both canvases.

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -6,5 +6,6 @@ Browser interface providing live preview and controls.
 - `main.mjs` – entry point for JS logic, wiring modules together, exposes a 'run' function.
 - `connection.mjs` – WebSocket setup and message handling.
 - `ui-controls.mjs` – wires DOM controls to params and renders effect-specific widgets.
+- Preset controls allow saving and loading configuration snapshots.
 - `controls/` – reusable widgets and `renderControls` helper.
 - `renderer.mjs` – scene generation and drawing, duplicating a single scene to both canvases.

--- a/src/ui/ui-controls.mjs
+++ b/src/ui/ui-controls.mjs
@@ -2,6 +2,7 @@ import { effects } from '../effects/index.mjs';
 import { renderControls } from './controls/index.mjs';
 import { rgbToHex } from './controls/utils.mjs';
 import { initSpeedSlider } from './controls/speedSlider.mjs';
+import { refreshPresetDropdown } from './presets.mjs';
 
 let sendFn = null;
 let currentEffectId = null;
@@ -127,31 +128,24 @@ export function initUI(win, doc, P, send, onToggleFreeze){
 
   const presetInput = doc.getElementById('presetName');
   const presetList = doc.getElementById('presetList');
-  async function refreshPresets(){
-    if (!presetList) return;
-    const res = await win.fetch('/presets');
-    const names = await res.json();
-    presetList.innerHTML = '';
-    names.forEach(n => {
-      const opt = doc.createElement('option');
-      opt.value = n;
-      presetList.appendChild(opt);
-    });
+  if (presetList){
+    presetList.onchange = () => { if (presetInput) presetInput.value = presetList.value; };
+    refreshPresetDropdown(win, doc, presetList);
   }
-  refreshPresets();
   const saveBtn = doc.getElementById('savePreset');
   if (saveBtn){
     saveBtn.onclick = async () => {
-      const name = presetInput?.value.trim();
+      const name = presetInput?.value.trim() || presetList?.value;
       if (!name) return;
       await win.fetch(`/preset/save/${encodeURIComponent(name)}`, { method: 'POST' });
-      refreshPresets();
+      await refreshPresetDropdown(win, doc, presetList);
+      if (presetInput) presetInput.value = name;
     };
   }
   const loadBtn = doc.getElementById('loadPreset');
   if (loadBtn){
     loadBtn.onclick = async () => {
-      const name = presetInput?.value.trim();
+      const name = presetInput?.value.trim() || presetList?.value;
       if (!name) return;
       await win.fetch(`/preset/load/${encodeURIComponent(name)}`);
     };

--- a/src/ui/ui-controls.mjs
+++ b/src/ui/ui-controls.mjs
@@ -125,6 +125,38 @@ export function initUI(win, doc, P, send, onToggleFreeze){
     updateYaw = initSpeedSlider(yawEl, P, send, 'yawSpeed', Math.PI);
   }
 
+  const presetInput = doc.getElementById('presetName');
+  const presetList = doc.getElementById('presetList');
+  async function refreshPresets(){
+    if (!presetList) return;
+    const res = await win.fetch('/presets');
+    const names = await res.json();
+    presetList.innerHTML = '';
+    names.forEach(n => {
+      const opt = doc.createElement('option');
+      opt.value = n;
+      presetList.appendChild(opt);
+    });
+  }
+  refreshPresets();
+  const saveBtn = doc.getElementById('savePreset');
+  if (saveBtn){
+    saveBtn.onclick = async () => {
+      const name = presetInput?.value.trim();
+      if (!name) return;
+      await win.fetch(`/preset/save/${encodeURIComponent(name)}`, { method: 'POST' });
+      refreshPresets();
+    };
+  }
+  const loadBtn = doc.getElementById('loadPreset');
+  if (loadBtn){
+    loadBtn.onclick = async () => {
+      const name = presetInput?.value.trim();
+      if (!name) return;
+      await win.fetch(`/preset/load/${encodeURIComponent(name)}`);
+    };
+  }
+
   win.addEventListener('keydown', (e) => {
     if (e.key === '1') effect.value = 'gradient', effect.onchange();
     if (e.key === '2') effect.value = 'solid', effect.onchange();

--- a/test/preset-ui.test.mjs
+++ b/test/preset-ui.test.mjs
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { refreshPresetDropdown } from '../src/ui/presets.mjs';
+
+test('preset dropdown matches fetched names', async () => {
+  const names = ['one','two'];
+  const win = { fetch: async () => ({ json: async () => names }) };
+  const doc = {
+    createElement(tag){
+      return { tag, value: '', textContent: '', appendChild(){}};
+    }
+  };
+  const select = {
+    innerHTML: '',
+    options: [],
+    appendChild(opt){ this.options.push(opt); }
+  };
+  await refreshPresetDropdown(win, doc, select);
+  assert.equal(select.options.length, names.length);
+  assert.deepEqual(select.options.map(o => o.value), names);
+});

--- a/test/preset.test.mjs
+++ b/test/preset.test.mjs
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { savePreset, loadPreset, listPresets } from '../src/config-store.mjs';
+import { unlink } from 'node:fs/promises';
+import path from 'node:path';
+import url from 'node:url';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const presetPath = path.resolve(__dirname, '../config/presets/test.json');
+
+const sampleParams = {
+  fpsCap: 30,
+  effect: 'solid',
+  effects: { solid: { r: 1, g: 0, b: 0 } },
+  post: {
+    brightness: 0.5,
+    tint: [1,1,1],
+    gamma: 1,
+    strobeHz: 0,
+    strobeDuty: 0.5,
+    strobeLow: 0,
+    pitchSpeed: 0,
+    yawSpeed: 0
+  }
+};
+
+test('save and load preset', async () => {
+  await savePreset('test', sampleParams);
+  const loaded = await loadPreset('test');
+  assert.deepEqual(loaded, sampleParams);
+  const list = await listPresets();
+  assert(list.includes('test'));
+  await unlink(presetPath);
+});

--- a/test/readme.md
+++ b/test/readme.md
@@ -5,6 +5,7 @@ Automated checks for BarnLights Playbox:
 - `engine.test.mjs` – validates engine output and config section lengths.
 - `engine-layout.test.mjs` – ensures layout loading rejects malformed files.
 - `config.test.mjs` – verifies configuration LED totals and section bounds.
+- `preset.test.mjs` – saves and loads effect presets.
 - `web.test.mjs` – loads the browser preview and fails on console errors.
 
 The engine exports a `start` function and is invoked via `bin/engine.mjs`, which also launches the HTTP server. Web server and engine can be invoked indepndenly for testing.

--- a/test/readme.md
+++ b/test/readme.md
@@ -6,6 +6,7 @@ Automated checks for BarnLights Playbox:
 - `engine-layout.test.mjs` – ensures layout loading rejects malformed files.
 - `config.test.mjs` – verifies configuration LED totals and section bounds.
 - `preset.test.mjs` – saves and loads effect presets.
+- `preset-ui.test.mjs` – ensures the preset dropdown reflects available files.
 - `web.test.mjs` – loads the browser preview and fails on console errors.
 
 The engine exports a `start` function and is invoked via `bin/engine.mjs`, which also launches the HTTP server. Web server and engine can be invoked indepndenly for testing.


### PR DESCRIPTION
## Summary
- allow saving and loading effect presets
- expose preset save/load endpoints
- wire up UI controls and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae140334c883228c3a54710eb035dd