### PR TITLE
Add digital rain effect

### DIFF
--- a/src/effects/index.mjs
+++ b/src/effects/index.mjs
@@ -2,10 +2,12 @@ import * as gradient from './library/gradient.mjs';
 import * as solid from './library/solid.mjs';
 import * as fire from './library/fire.mjs';
 import * as fireShader from './library/fireShader.mjs';
+import * as digitalRain from './library/digitalRain.mjs';
 
 export const effects = {
   [gradient.id]: gradient,
   [solid.id]: solid,
   [fire.id]: fire,
   [fireShader.id]: fireShader,
+  [digitalRain.id]: digitalRain,
 };

--- a/src/effects/library/digitalRain.mjs
+++ b/src/effects/library/digitalRain.mjs
@@ -1,0 +1,52 @@
+const fract = x => x - Math.floor(x);
+const rand = n => fract(Math.sin(n) * 43758.5453123);
+
+export const id = 'digitalRain';
+export const displayName = 'Digital Rain';
+export const defaultParams = {
+  dropSpeed: 0.6,
+  dropSize: 1,
+  numberOfDrops: 40,
+  tailLength: 8,
+  dropColor: [0.0, 1.0, 0.0],
+};
+export const paramSchema = {
+  dropSpeed: { type: 'number', min: 0, max: 5, step: 0.01, label: 'Drop Speed' },
+  dropSize: { type: 'number', min: 1, max: 10, step: 1, label: 'Drop Width' },
+  numberOfDrops: { type: 'number', min: 1, max: 200, step: 1, label: 'Drops' },
+  tailLength: { type: 'number', min: 1, max: 50, step: 1, label: 'Tail Length' },
+  dropColor: { type: 'color', label: 'Drop Color' },
+};
+
+export function render(sceneF32, W, H, t, params){
+  const {
+    dropSpeed = defaultParams.dropSpeed,
+    dropSize = defaultParams.dropSize,
+    numberOfDrops = defaultParams.numberOfDrops,
+    tailLength = defaultParams.tailLength,
+    dropColor = defaultParams.dropColor,
+  } = params || {};
+
+  sceneF32.fill(0);
+
+  const maxX = Math.max(1, W - dropSize);
+  const cycle = H + tailLength;
+
+  for (let d = 0; d < numberOfDrops; d++){
+    const x0 = Math.floor(rand(d) * maxX);
+    const offset = rand(d + 1000) * cycle;
+    const headY = (t * dropSpeed * H + offset) % cycle;
+    for (let i = 0; i < tailLength; i++){
+      const y = Math.floor(headY) - i;
+      if (y < 0 || y >= H) continue;
+      const fade = 1 - i / tailLength;
+      for (let x = x0; x < x0 + dropSize && x < W; x++){
+        const idx = (y * W + x) * 3;
+        sceneF32[idx] = dropColor[0] * fade;
+        sceneF32[idx + 1] = dropColor[1] * fade;
+        sceneF32[idx + 2] = dropColor[2] * fade;
+      }
+    }
+  }
+}
+

--- a/src/effects/library/readme.md
+++ b/src/effects/library/readme.md
@@ -4,5 +4,6 @@ One file per visual effect. Each module exports the following:
 `{ id, displayName, defaultParams, paramSchema, render }`.
 Note that this includes its own render function, and parameters for modification.
 
-Available effects include `gradient`, `solid`, `fire`, and the shader-based `fireShader`.
+Available effects include `gradient`, `solid`, `fire`, `digitalRain`, and the shader-based `fireShader`.
+The `digitalRain` effect renders falling streaks reminiscent of the Matrix.
 The `gradient` effect now supports arbitrary color stops for flexible palettes.

--- a/src/effects/readme.md
+++ b/src/effects/readme.md
@@ -2,7 +2,7 @@
 
 Effect modules and utilities for the renderer.
 
-- `library/` – individual effect implementations (e.g. gradient, solid, fire, fireShader).
+- `library/` – individual effect implementations (e.g. gradient, solid, fire, digitalRain, fireShader).
 - `index.mjs` – aggregates the library into an `effects` map keyed by id.
 - `modifiers.mjs` – shared modifiers and sampling helpers, including pitch/yaw transforms.
   Provides both clamped (`bilinearSampleRGB`) and wrapping (`bilinearSampleWrapRGB`) bilinear sampling.

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -32,12 +32,7 @@
     <legend>Effect</legend>
     <div class="row">
       <label>Effect
-        <select id="effect">
-          <option>gradient</option>
-          <option>solid</option>
-          <option>fire</option>
-          <option>fireShader</option>
-        </select>
+        <select id="effect"></select>
       </label>
     </div>
     <div class="row" id="effectControls"></div>
@@ -76,7 +71,7 @@
     </div>
   </fieldset>
 
-  <div>Hotkeys: <span class="kbd">1/2/3/4</span> effects, <span class="kbd">B</span> blackout (brightness=0), <span class="kbd">Space</span> freeze UI preview.</div>
+  <div>Hotkeys: <span class="kbd">1..9</span> effects, <span class="kbd">B</span> blackout (brightness=0), <span class="kbd">Space</span> freeze UI preview.</div>
 </div>
 
 <div class="barn">

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -2,7 +2,7 @@
 
 Browser interface providing live preview and controls.
 
-- `index.html` – control layout and canvas elements grouped into Effect, General, Strobe and Tint sections. The General section now includes pitch and yaw sliders for directional control.
+- `index.html` – control layout and canvas elements grouped into Effect, General, Strobe and Tint sections. The effect selector is populated at runtime from the shared effects map and the General section now includes pitch and yaw sliders for directional control.
 - `main.mjs` – entry point for JS logic, wiring modules together, exposes a 'run' function.
 - `connection.mjs` – WebSocket setup and message handling.
 - `ui-controls.mjs` – wires DOM controls to params and renders effect-specific widgets.

--- a/src/ui/ui-controls.mjs
+++ b/src/ui/ui-controls.mjs
@@ -73,8 +73,17 @@ export function applyUI(doc, P){
 export function initUI(win, doc, P, send, onToggleFreeze){
   sendFn = send;
   const effect = doc.getElementById('effect');
-  effect.value = P.effect;
-  effect.onchange = () => { send({ effect: effect.value }); renderEffectControls(doc,P); };
+  if (effect){
+    effect.innerHTML = '';
+    for (const id of Object.keys(effects)){
+      const opt = doc.createElement('option');
+      opt.value = id;
+      opt.textContent = id;
+      effect.appendChild(opt);
+    }
+    effect.value = P.effect;
+    effect.onchange = () => { send({ effect: effect.value }); renderEffectControls(doc,P); };
+  }
 
   const fps = doc.getElementById('fpsCap');
   const fpsV = doc.getElementById('fpsCap_v');
@@ -126,10 +135,14 @@ export function initUI(win, doc, P, send, onToggleFreeze){
   }
 
   win.addEventListener('keydown', (e) => {
-    if (e.key === '1') effect.value = 'gradient', effect.onchange();
-    if (e.key === '2') effect.value = 'solid', effect.onchange();
-    if (e.key === '3') effect.value = 'fire', effect.onchange();
-    if (e.key === '4') effect.value = 'fireShader', effect.onchange();
+    if (e.key >= '1' && e.key <= '9'){
+      const idx = e.key.charCodeAt(0) - '1'.charCodeAt(0);
+      const ids = Object.keys(effects);
+      if (idx < ids.length && effect){
+        effect.value = ids[idx];
+        effect.onchange();
+      }
+    }
     if (e.key.toLowerCase() === 'b') send({ brightness: 0 });
     if (e.key === ' ') onToggleFreeze();
   });


### PR DESCRIPTION
## Summary
- add digital rain effect with configurable drop speed, width, count, tail length and color
- expose effect in shared effects map
- document new effect in library and index README files

## Testing
- `npm test` *(fails: Navigation timeout of 30000 ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68ae164daa348322bc6c97841904baa1