### PR TITLE
docs: clarify init connection stages

### DIFF
--- a/src/ui/main.mjs
+++ b/src/ui/main.mjs
@@ -33,21 +33,29 @@ export async function run(docArg = globalThis.document){
 
   const params = {};
 
-  initConnection(win,
+  // Establish a WebSocket connection and describe how incoming messages are used.
+  initConnection(
+    win,
+    // Stage 1: handle initial scene setup from the server.
     (m) => {
+      // Store default parameters and allocate buffers for both walls.
       Object.assign(params, m.params);
       const sceneW = m.scene.w;
       const sceneH = m.scene.h;
       const leftFrame  = new Float32Array(sceneW * sceneH * 3);
       const rightFrame = new Float32Array(sceneW * sceneH * 3);
+      // Build the UI and start rendering frames if canvases are available.
       initUI(win, doc, params, send);
-      if (ctxL && ctxR) frame(win, doc, ctxL, ctxR, leftFrame, rightFrame, params, layoutLeft, layoutRight, sceneW, sceneH);
-      else setStatus(doc, "Preview unavailable");
+      if (ctxL && ctxR){
+        frame(win, doc, ctxL, ctxR, leftFrame, rightFrame, params, layoutLeft, layoutRight, sceneW, sceneH);
+      } else setStatus(doc, "Preview unavailable");
     },
+    // Stage 2: apply live parameter updates pushed by the server.
     (m) => {
       Object.assign(params, m.params);
       applyUI(doc, params);
     },
+    // Stage 3: display connection errors or status updates.
     (msg) => setStatus(doc, msg)
   );
 }


### PR DESCRIPTION
## Summary
- comment initConnection call to document initialization, live updates, and error stages

## Testing
- `npm test` *(fails: web view loads with no console errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae237228cc8322b69208a177933b12