### PR TITLE
feat(ui): show pitch/yaw angles

### DIFF
--- a/src/effects/post.mjs
+++ b/src/effects/post.mjs
@@ -25,6 +25,8 @@ function applyTransform(sceneF32, t, post, W, H){
   yaw += post.yawSpeed * dt;
   const sx = ((pitch % W) + W) % W;
   const ang = yaw % (Math.PI * 2);
+  post.pitch = (sx / W) * 360;
+  post.yaw = ((ang * 180 / Math.PI) + 360) % 360;
   _transformScene(sceneF32, W, H, sx, 0, ang);
 }
 

--- a/src/engine.mjs
+++ b/src/engine.mjs
@@ -27,6 +27,8 @@ export const params = {
     strobeLow: 0.0,
     pitchSpeed: 0,
     yawSpeed: 0,
+    pitch: 0,
+    yaw: 0,
   }
 };
 

--- a/src/ui/controls-logic.mjs
+++ b/src/ui/controls-logic.mjs
@@ -58,7 +58,7 @@ function applyFpsCap(doc, P){
  */
 function applyPost(doc, P){
   for (const [key,val] of Object.entries(P.post)){
-    if (key === 'tint') continue;
+    if (key === 'tint' || key === 'pitch' || key === 'yaw') continue;
     const el = doc.getElementById(key);
     const span = doc.getElementById(key + '_v');
     if (!el) continue;
@@ -146,13 +146,23 @@ export function initUI(win, doc, P, send){
   });
 
   const pitchEl = doc.getElementById('pitch');
+  const pitchDeg = doc.getElementById('pitchDeg');
   if (pitchEl){
     updatePitch = initSpeedSlider(pitchEl, P, send, 'pitchSpeed', 500);
   }
+
   const yawEl = doc.getElementById('yaw');
+  const yawDeg = doc.getElementById('yawDeg');
   if (yawEl){
     updateYaw = initSpeedSlider(yawEl, P, send, 'yawSpeed', Math.PI);
   }
+
+  const updateAngles = () => {
+    if (pitchDeg) pitchDeg.value = Math.abs(P.post.pitch || 0).toFixed(1);
+    if (yawDeg) yawDeg.value = Math.abs(P.post.yaw || 0).toFixed(1);
+    win.requestAnimationFrame(updateAngles);
+  };
+  updateAngles();
 
   const presetInput = doc.getElementById('presetName');
   const presetList = doc.getElementById('presetList');

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -48,20 +48,28 @@
     </div>
   </fieldset>
 
-  <fieldset>
-    <legend>General</legend>
-    <div class="row">
-      <label>Brightness <input id="brightness" type="range" min="0" max="1" step="0.01"><span id="brightness_v"></span></label>
-      <label>Gamma <input id="gamma" type="range" min="0.5" max="3" step="0.01"><span id="gamma_v"></span><small class="desc">brightness curve</small></label>
-      <label>Pitch
-        <div id="pitch" class="hslider"><div class="handle"></div></div>
-      </label>
-      <label>Yaw
-        <div id="yaw" class="hslider"><div class="handle"></div></div>
-      </label>
-      <label>FPS cap <input id="fpsCap" type="range" min="1" max="60" step="1"><span id="fpsCap_v"></span></label>
-    </div>
-  </fieldset>
+    <fieldset>
+      <legend>General</legend>
+      <div class="row">
+        <label>Brightness <input id="brightness" type="range" min="0" max="1" step="0.01"><span id="brightness_v"></span></label>
+        <label>Gamma <input id="gamma" type="range" min="0.5" max="3" step="0.01"><span id="gamma_v"></span><small class="desc">brightness curve</small></label>
+        <label>FPS cap <input id="fpsCap" type="range" min="1" max="60" step="1"><span id="fpsCap_v"></span></label>
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <legend>Orientation</legend>
+      <div class="row">
+        <label>Pitch
+          <div id="pitch" class="hslider"><div class="handle"></div></div>
+          <input id="pitchDeg" type="number" min="0" max="360" step="0.1" readonly style="width:60px">
+        </label>
+        <label>Yaw
+          <div id="yaw" class="hslider"><div class="handle"></div></div>
+          <input id="yawDeg" type="number" min="0" max="360" step="0.1" readonly style="width:60px">
+        </label>
+      </div>
+    </fieldset>
 
   <fieldset>
     <legend>Strobe</legend>

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -2,7 +2,7 @@
 
 Browser interface providing live preview and controls.
 
-- `index.html` – control layout and canvas elements grouped into Effect, General, Strobe and Tint sections. The effect selector is populated at runtime from the shared effects map and the General section now includes pitch and yaw sliders for directional control.
+- `index.html` – control layout and canvas elements grouped into Effect, General, Orientation, Strobe and Tint sections. Pitch and yaw speed sliders live under Orientation while read-only numeric inputs display their absolute angles in degrees. The effect selector is populated at runtime from the shared effects map.
 - `main.mjs` – entry point for JS logic, wiring modules together, exposes a 'run' function.
 - `connection.mjs` – WebSocket setup and message handling.
 - `controls-logic.mjs` – wires DOM controls to params and renders effect-specific widgets.

--- a/src/ui/subviews/readme.md
+++ b/src/ui/subviews/readme.md
@@ -11,7 +11,7 @@ Dynamic UI widgets for effect parameters.
 
 The `fireShader` and `gradient` effects use the `colorStops` widget to define their color palettes.
 
-Additional widgets support motion controls used by the General panel:
+Additional widgets support motion controls used by the Orientation panel:
 - `speedSlider.mjs` – horizontal slider with a 5% center dead zone for pitch and yaw speeds.
 
 Utilities for RGB conversions live in `utils.mjs`.

--- a/test/preset.test.mjs
+++ b/test/preset.test.mjs
@@ -20,7 +20,9 @@ const sampleParams = {
     strobeDuty: 0.5,
     strobeLow: 0,
     pitchSpeed: 0,
-    yawSpeed: 0
+    yawSpeed: 0,
+    pitch: 0,
+    yaw: 0
   }
 };
 


### PR DESCRIPTION
## Summary
- display absolute pitch and yaw angles with read-only numeric inputs
- compute orientation angles from speeds during post-processing and expose them to the UI
- simplify speed slider and update docs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae5781979c8322ad57326d5fe700b1