### PR TITLE
Add diagonal stripes effect

### DIFF
--- a/src/effects/index.mjs
+++ b/src/effects/index.mjs
@@ -3,6 +3,7 @@ import * as solid from './library/solid.mjs';
 import * as fire from './library/fire.mjs';
 import * as fireShader from './library/fireShader.mjs';
 import * as digitalRain from './library/digitalRain.mjs';
+import * as diagonalStripes from './library/diagonalStripes.mjs';
 
 export const effects = {
   [gradient.id]: gradient,
@@ -10,4 +11,5 @@ export const effects = {
   [fire.id]: fire,
   [fireShader.id]: fireShader,
   [digitalRain.id]: digitalRain,
+  [diagonalStripes.id]: diagonalStripes,
 };

--- a/src/effects/library/diagonalStripes.mjs
+++ b/src/effects/library/diagonalStripes.mjs
@@ -1,0 +1,40 @@
+export const id = 'diagonalStripes';
+export const displayName = 'Diagonal Stripes';
+export const defaultParams = {
+  colorA: [1.0, 1.0, 1.0],
+  colorB: [0.0, 0.0, 0.0],
+  width: 0.1,
+  angle: 45,
+};
+export const paramSchema = {
+  colorA: { type: 'color', label: 'Color A' },
+  colorB: { type: 'color', label: 'Color B' },
+  width: { type: 'number', min: 0.01, max: 1, step: 0.01 },
+  angle: { type: 'number', min: 0, max: 180, step: 1 },
+};
+
+export function render(sceneF32, W, H, t, params){
+  const {
+    colorA = [1, 1, 1],
+    colorB = [0, 0, 0],
+    width = 0.1,
+    angle = 45,
+  } = params;
+  const diag = Math.hypot(W, H);
+  const stripeWidth = Math.max(1e-6, width) * diag;
+  const rad = angle * Math.PI / 180;
+  const cosA = Math.cos(rad);
+  const sinA = Math.sin(rad);
+  let i = 0;
+  for(let y = 0; y < H; y++){
+    for(let x = 0; x < W; x++){
+      const coord = x * cosA - y * sinA;
+      const stripeIndex = Math.floor(coord / stripeWidth);
+      const useA = (stripeIndex & 1) === 0;
+      const c = useA ? colorA : colorB;
+      sceneF32[i++] = c[0];
+      sceneF32[i++] = c[1];
+      sceneF32[i++] = c[2];
+    }
+  }
+}

--- a/src/effects/readme.md
+++ b/src/effects/readme.md
@@ -2,7 +2,7 @@
 
 Effect modules and utilities for the renderer.
 
-- `library/` – individual effect implementations (e.g. gradient, solid, fire, digitalRain, fireShader).
+- `library/` – individual effect implementations (e.g. gradient, solid, fire, digitalRain, fireShader, diagonalStripes).
 - `index.mjs` – aggregates the library into an `effects` map keyed by id.
 - `modifiers.mjs` – shared modifiers and sampling helpers, including pitch/yaw transforms.
   Provides both clamped (`bilinearSampleRGB`) and wrapping (`bilinearSampleWrapRGB`) bilinear sampling.

--- a/test/diagonalStripes.test.mjs
+++ b/test/diagonalStripes.test.mjs
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'assert/strict';
+import * as diagonalStripes from '../src/effects/library/diagonalStripes.mjs';
+
+const eq = (a, b) => assert.deepEqual(a.map(n => +n.toFixed(5)), b.map(n => +n.toFixed(5)));
+const get = (scene, W, x, y) => {
+  const i = (y * W + x) * 3;
+  return [scene[i], scene[i + 1], scene[i + 2]];
+};
+
+test('diagonal stripes at 45 degrees', () => {
+  const W = 4, H = 4;
+  const scene = new Float32Array(W * H * 3);
+  diagonalStripes.render(scene, W, H, 0, {
+    colorA: [1, 0, 0],
+    colorB: [0, 0, 1],
+    width: 0.25,
+    angle: 45,
+  });
+  eq(get(scene, W, 0, 0), [1, 0, 0]);
+  eq(get(scene, W, 1, 0), [1, 0, 0]);
+  eq(get(scene, W, 0, 1), [0, 0, 1]);
+  eq(get(scene, W, 2, 2), [1, 0, 0]);
+});
+
+test('angle parameter rotates stripes', () => {
+  const W = 4, H = 4;
+  const scene = new Float32Array(W * H * 3);
+  diagonalStripes.render(scene, W, H, 0, {
+    colorA: [1, 0, 0],
+    colorB: [0, 1, 0],
+    width: 0.25,
+    angle: 0,
+  });
+  eq(get(scene, W, 0, 0), [1, 0, 0]);
+  eq(get(scene, W, 0, 1), [1, 0, 0]);
+  eq(get(scene, W, 2, 0), [0, 1, 0]);
+  eq(get(scene, W, 2, 3), [0, 1, 0]);
+});


### PR DESCRIPTION
## Summary
- add diagonal stripes effect with configurable colors, width, and angle
- register effect and document in effects readme
- test diagonal stripe rendering for orientation and color accuracy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae58414bac8322bb3bf08b9685b61d