### PR TITLE
Remove UI hotkey functionality

### DIFF
--- a/src/ui/controls-logic.mjs
+++ b/src/ui/controls-logic.mjs
@@ -189,17 +189,5 @@ export function initUI(win, doc, P, send){
     };
   }
 
-  win.addEventListener('keydown', (e) => {
-    if (e.key >= '1' && e.key <= '9'){
-      const idx = e.key.charCodeAt(0) - '1'.charCodeAt(0);
-      const ids = Object.keys(effects);
-      if (idx < ids.length && effect){
-        effect.value = ids[idx];
-        effect.onchange();
-      }
-    }
-    if (e.key.toLowerCase() === 'b') send({ brightness: 0 });
-  });
-
   applyUI(doc, P);
 }

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -17,7 +17,6 @@
   #left { transform: rotateY(15deg) skewY(-2deg); }
   #right{ transform: rotateY(-15deg) skewY(2deg);  }
   .panel { display:flex; flex-direction:column; gap:var(--gap); align-items:flex-start; }
-  .kbd { padding:1px 6px; border:1px solid #ccc; border-radius:4px; background:#f7f7f7; font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
   .hslider { width:180px; height:20px; position:relative; border:1px solid #ccc; border-radius:10px; background:#f3f3f3; touch-action:none; }
   .hslider .handle { position:absolute; width:12px; height:12px; border-radius:50%; background:#666; top:50%; transform:translate(-50%,-50%); left:50%; }
 </style>
@@ -89,7 +88,6 @@
     </div>
   </fieldset>
 
-  <div>Hotkeys: <span class="kbd">1..9</span> effects, <span class="kbd">B</span> blackout (brightness=0), <span class="kbd">Space</span> freeze UI preview.</div>
 </div>
 
 <div class="barn">

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -10,3 +10,4 @@ Browser interface providing live preview and controls.
 - Preset controls allow saving and loading configuration snapshots.
 - `subviews/` – reusable widgets and `renderControls` helper.
 - `preview-renderer.mjs` – scene generation and drawing, duplicating a single scene to both canvases.
+- Keyboard shortcuts were removed; all interactions occur through on-screen controls.


### PR DESCRIPTION
## Summary
- remove keyboard shortcut handler and blackout shortcut from controls logic
- drop hotkey hints and unused styles from the UI markup
- document the absence of hotkeys in the UI module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae5b9079708322b448557d3eaea743