### PR TITLE
Enable manual pitch/yaw angle entry

### DIFF
--- a/src/effects/post.mjs
+++ b/src/effects/post.mjs
@@ -23,6 +23,8 @@ function applyTransform(sceneF32, t, post, W, H){
   lastT = t;
   pitch += post.pitchSpeed * dt;
   yaw += post.yawSpeed * dt;
+  if (post.pitchSpeed === 0) pitch = (post.pitch || 0) / 360 * W;
+  if (post.yawSpeed === 0) yaw = (post.yaw || 0) * Math.PI / 180;
   const sx = ((pitch % W) + W) % W;
   const ang = yaw % (Math.PI * 2);
   post.pitch = (sx / W) * 360;

--- a/src/effects/readme.md
+++ b/src/effects/readme.md
@@ -6,7 +6,7 @@ Effect modules and utilities for the renderer.
 - `index.mjs` – aggregates the library into an `effects` map keyed by id.
 - `modifiers.mjs` – shared modifiers and sampling helpers, including pitch/yaw transforms.
   Provides both clamped (`bilinearSampleRGB`) and wrapping (`bilinearSampleWrapRGB`) bilinear sampling.
-- `post.mjs` – post-processing pipeline and modifier registration.
+- `post.mjs` – post-processing pipeline and modifier registration; respects manual pitch/yaw angles when speeds are zero.
 
 The `transformScene` helper uses wrapping bilinear sampling so that shifts and rotations 
 loop seamlessly across scene edges.

--- a/src/ui/controls-logic.mjs
+++ b/src/ui/controls-logic.mjs
@@ -150,16 +150,38 @@ export function initUI(win, doc, P, send){
   if (pitchEl){
     updatePitch = initSpeedSlider(pitchEl, P, send, 'pitchSpeed', 500);
   }
+  if (pitchDeg){
+    pitchDeg.onchange = () => {
+      const v = parseFloat(pitchDeg.value);
+      if (Number.isFinite(v)){
+        P.post.pitch = v;
+        P.post.pitchSpeed = 0;
+        send({ pitch: v, pitchSpeed: 0 });
+        if (updatePitch) updatePitch(0);
+      }
+    };
+  }
 
   const yawEl = doc.getElementById('yaw');
   const yawDeg = doc.getElementById('yawDeg');
   if (yawEl){
     updateYaw = initSpeedSlider(yawEl, P, send, 'yawSpeed', Math.PI);
   }
+  if (yawDeg){
+    yawDeg.onchange = () => {
+      const v = parseFloat(yawDeg.value);
+      if (Number.isFinite(v)){
+        P.post.yaw = v;
+        P.post.yawSpeed = 0;
+        send({ yaw: v, yawSpeed: 0 });
+        if (updateYaw) updateYaw(0);
+      }
+    };
+  }
 
   const updateAngles = () => {
-    if (pitchDeg) pitchDeg.value = Math.abs(P.post.pitch || 0).toFixed(1);
-    if (yawDeg) yawDeg.value = Math.abs(P.post.yaw || 0).toFixed(1);
+    if (pitchDeg && doc.activeElement !== pitchDeg) pitchDeg.value = Math.abs(P.post.pitch || 0).toFixed(1);
+    if (yawDeg && doc.activeElement !== yawDeg) yawDeg.value = Math.abs(P.post.yaw || 0).toFixed(1);
     win.requestAnimationFrame(updateAngles);
   };
   updateAngles();

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -61,11 +61,11 @@
       <div class="row">
         <label>Pitch
           <div id="pitch" class="hslider"><div class="handle"></div></div>
-          <input id="pitchDeg" type="number" min="0" max="360" step="0.1" readonly style="width:60px">
+          <input id="pitchDeg" type="number" min="0" max="360" step="0.1" style="width:60px">
         </label>
         <label>Yaw
           <div id="yaw" class="hslider"><div class="handle"></div></div>
-          <input id="yawDeg" type="number" min="0" max="360" step="0.1" readonly style="width:60px">
+          <input id="yawDeg" type="number" min="0" max="360" step="0.1" style="width:60px">
         </label>
       </div>
     </fieldset>

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -2,7 +2,7 @@
 
 Browser interface providing live preview and controls.
 
-- `index.html` – control layout and canvas elements grouped into Effect, General, Orientation, Strobe and Tint sections. Pitch and yaw speed sliders live under Orientation while read-only numeric inputs display their absolute angles in degrees. The effect selector is populated at runtime from the shared effects map.
+- `index.html` – control layout and canvas elements grouped into Effect, General, Orientation, Strobe and Tint sections. Pitch and yaw speed sliders live under Orientation while editable numeric inputs allow setting their absolute angles in degrees and zeroing the respective speeds. The effect selector is populated at runtime from the shared effects map.
 - `main.mjs` – entry point for JS logic, wiring modules together, exposes a 'run' function.
 - `connection.mjs` – WebSocket setup and message handling.
 - `controls-logic.mjs` – wires DOM controls to params and renders effect-specific widgets.


### PR DESCRIPTION
## Summary
- allow typing into pitch/yaw angle inputs
- zero pitch/yaw speeds when manual angles are entered
- document orientation input behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae5e02f2608322b4ec8bf39eeb8d2d