### PR TITLE
feat: center preview and horizontal control sections

### DIFF
--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -5,18 +5,18 @@
   :root { --gap: 20px; }
   body { font: 14px system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 20px; color:#111; }
   h1 { margin: 0 0 8px; font-size: 20px; }
-  .row { display:flex; gap: var(--gap); align-items:center; margin: 6px 0; flex-wrap: wrap; }
+  .row { display:flex; flex-direction:column; gap: var(--gap); align-items:flex-start; margin: 6px 0; }
   label { display:flex; align-items:center; gap:8px; min-width: 220px; }
   input[type="range"] { width: 180px; }
   select { padding: 4px 6px; }
-  fieldset { border:1px solid #ccc; padding:10px 14px; margin-bottom:var(--gap); }
+  fieldset { border:1px solid #ccc; padding:10px 14px; margin:0; }
   legend { padding:0 6px; font-weight:bold; }
   .desc { font-size:12px; color:#555; }
-  .barn { display:flex; gap: 32px; perspective: 900px; margin-top: 16px; }
+  .barn { display:flex; gap: 32px; perspective: 900px; margin:16px auto; justify-content:center; }
   canvas { width: 512px; height: 128px; image-rendering: pixelated; border-radius: 10px; box-shadow: 0 10px 30px rgba(0,0,0,.25); background:#000; }
   #left { transform: rotateY(15deg) skewY(-2deg); }
   #right{ transform: rotateY(-15deg) skewY(2deg);  }
-  .panel { display:flex; flex-direction:column; gap:var(--gap); align-items:flex-start; }
+  .panel { display:flex; flex-direction:row; gap:var(--gap); align-items:flex-start; flex-wrap:wrap; }
   .hslider { width:180px; height:20px; position:relative; border:1px solid #ccc; border-radius:10px; background:#f3f3f3; touch-action:none; }
   .hslider .handle { position:absolute; width:12px; height:12px; border-radius:50%; background:#666; top:50%; transform:translate(-50%,-50%); left:50%; }
 </style>
@@ -26,6 +26,10 @@
 
   <h1>BarnLights Playbox</h1>
   <div id="status"></div>
+<div class="barn">
+  <canvas id="left"  width="512" height="128"></canvas>
+  <canvas id="right" width="512" height="128"></canvas>
+</div>
 <div class="panel">
   <fieldset>
     <legend>Effect</legend>
@@ -88,11 +92,6 @@
     </div>
   </fieldset>
 
-</div>
-
-<div class="barn">
-  <canvas id="left"  width="512" height="128"></canvas>
-  <canvas id="right" width="512" height="128"></canvas>
 </div>
 
 <script type="module">

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -1,8 +1,8 @@
 # UI
 
-Browser interface providing live preview and controls.
+Browser interface providing a live preview above a panel of controls.
 
-- `index.html` – control layout and canvas elements grouped into Effect, General, Orientation, Strobe and Tint sections. Pitch and yaw speed sliders live under Orientation while read-only numeric inputs display their absolute angles in degrees. The effect selector is populated at runtime from the shared effects map.
+- `index.html` – renders canvases first, centred at the top. Control sections (Effect, Presets, General, Orientation, Strobe and Tint) are displayed side by side while each section stacks its controls vertically. Pitch and yaw speed sliders live under Orientation while read-only numeric inputs display their absolute angles in degrees. The effect selector is populated at runtime from the shared effects map.
 - `main.mjs` – entry point for JS logic, wiring modules together, exposes a 'run' function.
 - `connection.mjs` – WebSocket setup and message handling.
 - `controls-logic.mjs` – wires DOM controls to params and renders effect-specific widgets.


### PR DESCRIPTION
## Summary
- Center preview canvases at the top of the page
- Arrange control sections horizontally with vertically stacked controls
- Document updated UI layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae5e8995c483228cbf516173759273