### PR TITLE
Centralize render mode handling with shared helper

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Minimal Node + browser setup that:
 
 Runtime parameters are grouped under `effects` for effect-specific settings
 and `post` for modifiers like brightness, tint and strobe which can be applied on top.
-A `renderMode` parameter controls how scenes map to the two walls: `duplicate` renders once for both, `extended` renders a double-width scene and splits it, and `mirror` flips the scene for the right wall. Both the engine and browser preview rely on `renderFrames` to handle these modes.
+A `renderMode` parameter controls how scenes map to the two walls: `duplicate` renders once for both, `extended` renders a double-width scene and splits it, and `mirror` flips the scene horizontally for the right wall. Both the engine and browser preview rely on `renderFrames` to handle these modes.
 
 ## Frame pipeline
 1. `renderFrames` draws the active effect, applies post-processing and fills the `leftFrame` and `rightFrame` buffers based on `renderMode`.

--- a/readme.md
+++ b/readme.md
@@ -10,20 +10,19 @@ Minimal Node + browser setup that:
 
 ## Architecture
 - `bin/engine.mjs` launches the HTTP server and invokes the engine's `start` function, streaming NDJSON frames.
-- `src/render-scene.mjs` implements shared scene rendering and post-processing.
-- `src/engine.mjs` renders frames and exposes live parameters.
+- `src/render-scene.mjs` implements shared scene rendering, post-processing and the `renderFrames` helper used by both the engine and UI.
+- `src/engine.mjs` runs the render loop with `renderFrames` and exposes live parameters.
 - `src/server.mjs` exports a `startServer` helper that serves the UI and relays WebSocket param updates.
 - `src/ui/` contains the browser preview and controls.
 
 Runtime parameters are grouped under `effects` for effect-specific settings
 and `post` for modifiers like brightness, tint and strobe which can be applied on top.
-A `renderMode` parameter controls how scenes map to the two walls: `duplicate` renders once for both, `extended` renders a double-width scene and splits it, and `mirror` flips the scene for the right wall.
+A `renderMode` parameter controls how scenes map to the two walls: `duplicate` renders once for both, `extended` renders a double-width scene and splits it, and `mirror` flips the scene for the right wall. Both the engine and browser preview rely on `renderFrames` to handle these modes.
 
 ## Frame pipeline
-1. The engine renders the active effect into a floating point RGB buffer (`leftFrame`).
-2. Post-processing modifiers run on that buffer and the result is combined into `rightFrame` according to `renderMode`.
-3. Each frame is sliced according to the configured layouts and emitted as base64-encoded `rgb8` NDJSON.
-4. The browser preview reuses these frame buffers to draw the scene and per-LED indicators.
+1. `renderFrames` draws the active effect, applies post-processing and fills the `leftFrame` and `rightFrame` buffers based on `renderMode`.
+2. Each frame is sliced according to the configured layouts and emitted as base64-encoded `rgb8` NDJSON.
+3. The browser preview reuses these frame buffers to draw the scene and per-LED indicators.
 
 ## Quick start
 1. Open your terminal

--- a/src/readme.md
+++ b/src/readme.md
@@ -2,8 +2,8 @@
 
 Core runtime code for BarnLights Playbox:
 
-- `render-scene.mjs` – shared scene rendering and post-processing helpers.
-- `engine.mjs` – side‑effect‑free render loop exposing `params` (including `renderMode`); call `start()` to emit SLICES_NDJSON.
+- `render-scene.mjs` – shared scene rendering, post-processing and `renderFrames` helper for mapping scenes to both walls.
+- `engine.mjs` – side‑effect‑free render loop using `renderFrames` and exposing `params` (including `renderMode`); call `start()` to emit SLICES_NDJSON.
 - `server.mjs` – HTTP/WebSocket server serving the UI and applying param updates.
 - `config-store.mjs` – read/write helpers for saving and loading effect presets.
 - `effects/` – effect implementations, registry and post-processing helpers.

--- a/src/render-scene.mjs
+++ b/src/render-scene.mjs
@@ -35,9 +35,10 @@ export function renderFrames(leftFrame, rightFrame, P, t){
   } else {
     renderScene(leftFrame, SCENE_W, SCENE_H, t, P);
     if (mode === "mirror"){
+      // flip horizontally: reflect x but keep y aligned
       for (let y = 0; y < SCENE_H; y++){
         for (let x = 0; x < SCENE_W; x++){
-          const src = ((SCENE_H - 1 - y) * SCENE_W + (SCENE_W - 1 - x)) * 3;
+          const src = (y * SCENE_W + (SCENE_W - 1 - x)) * 3;
           const dst = (y * SCENE_W + x) * 3;
           rightFrame[dst] = leftFrame[src];
           rightFrame[dst + 1] = leftFrame[src + 1];

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -6,6 +6,6 @@ Browser interface providing live preview and controls.
 - `main.mjs` – entry point for JS logic, wiring modules together, exposes a 'run' function.
 - `connection.mjs` – WebSocket setup and message handling.
 - `controls-logic.mjs` – wires DOM controls to params and renders effect-specific widgets.
-- `preview-renderer.mjs` – scene generation and drawing, duplicating a single scene to both canvases.
+- `renderer.mjs` – uses `renderFrames` to draw the scene for both walls and overlay per-LED indicators.
 - `presets.mjs` – handles saving/retreiving configuration and listing the saved options.
 - `subviews/` – reusable widgets and `renderControls` helper.

--- a/src/ui/renderer.mjs
+++ b/src/ui/renderer.mjs
@@ -1,8 +1,7 @@
 import { sliceSection, clamp01 } from "../effects/modifiers.mjs";
-import { renderScene } from "../render-scene.mjs";
+import { renderFrames } from "../render-scene.mjs";
 
 let offscreen = null, offCtx = null;
-let extendedFrame = null;
 
 function drawSceneToCanvas(ctx, sceneF32, sceneW, sceneH, win, doc){
   if (!offscreen || offscreen.width !== sceneW || offscreen.height !== sceneH){
@@ -68,35 +67,7 @@ export function frame(
   sceneW, sceneH
 ) {
   const t = win.performance.now() / 1000;
-  const mode = P.renderMode;
-  if (mode === "extended"){
-    const W = sceneW * 2;
-    if (!extendedFrame || extendedFrame.length !== W * sceneH * 3){
-      extendedFrame = new Float32Array(W * sceneH * 3);
-    }
-    renderScene(extendedFrame, W, sceneH, t, P);
-    for (let y = 0; y < sceneH; y++){
-      const src = y * W * 3;
-      const dst = y * sceneW * 3;
-      leftFrame.set(extendedFrame.subarray(src, src + sceneW * 3), dst);
-      rightFrame.set(extendedFrame.subarray(src + sceneW * 3, src + W * 3), dst);
-    }
-  } else {
-    renderScene(leftFrame, sceneW, sceneH, t, P);
-    if (mode === "mirror"){
-      for (let y = 0; y < sceneH; y++){
-        for (let x = 0; x < sceneW; x++){
-          const src = ((sceneH - 1 - y) * sceneW + (sceneW - 1 - x)) * 3;
-          const dst = (y * sceneW + x) * 3;
-          rightFrame[dst]   = leftFrame[src];
-          rightFrame[dst+1] = leftFrame[src+1];
-          rightFrame[dst+2] = leftFrame[src+2];
-        }
-      }
-    } else {
-      rightFrame.set(leftFrame);
-    }
-  }
+  renderFrames(leftFrame, rightFrame, P, t);
   drawSceneToCanvas(ctxL, leftFrame, sceneW, sceneH, win, doc);
   if (layoutLeft) drawSectionsToCanvas(ctxL, leftFrame, layoutLeft, sceneW, sceneH);
   drawSceneToCanvas(ctxR, rightFrame, sceneW, sceneH, win, doc);


### PR DESCRIPTION
## Summary
- Add `renderFrames` helper to unify duplicate/extended/mirror frame mapping
- Use `renderFrames` in engine and browser renderer to populate left/right buffers
- Document the shared render pipeline and render mode handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae61553dd88322ac35a8224ea05f47