### PR TITLE
Save preset preview thumbnails

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Minimal Node + browser setup that:
 - samples per your layout JSON into per-row "slices",
 - **emits SLICES_NDJSON to stdout** (one line per frame),
 - serves a **live preview** with a light barn perspective and per-LED colored dots.
-- allows saving and loading effect presets through the UI with a dropdown of saved presets.
+- allows saving and loading effect presets through the UI with a dropdown of saved presets, storing a preview thumbnail with each.
 
 ## Architecture
 - `bin/engine.mjs` launches the HTTP server and invokes the engine's `start` function, streaming NDJSON frames.

--- a/src/config-store.mjs
+++ b/src/config-store.mjs
@@ -15,10 +15,14 @@ export async function listPresets(){
   }
 }
 
-export async function savePreset(name, params){
+export async function savePreset(name, params, imageBuf){
   await fs.mkdir(PRESET_DIR, { recursive: true });
   const p = path.join(PRESET_DIR, `${name}.json`);
   await fs.writeFile(p, JSON.stringify(params, null, 2), "utf8");
+  if (imageBuf){
+    const imgPath = path.join(PRESET_DIR, `${name}.png`);
+    await fs.writeFile(imgPath, imageBuf);
+  }
 }
 
 export async function loadPreset(name){

--- a/src/readme.md
+++ b/src/readme.md
@@ -5,7 +5,7 @@ Core runtime code for BarnLights Playbox:
 - `render-scene.mjs` – shared scene rendering and post-processing helpers.
 - `engine.mjs` – side‑effect‑free render loop exposing `params` (including `renderMode`); call `start()` to emit SLICES_NDJSON.
 - `server.mjs` – HTTP/WebSocket server serving the UI and applying param updates.
-- `config-store.mjs` – read/write helpers for saving and loading effect presets.
+- `config-store.mjs` – read/write helpers for saving and loading effect presets and their preview images.
 - `effects/` – effect implementations, registry and post-processing helpers.
 - `ui/` – browser UI for preview and controls, can modify the `params` which the engine renders.
 - `ui/presets.mjs` – helper to fetch preset names and update the UI dropdown.

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -50,7 +50,10 @@ const server = http.createServer(async (req, res) => {
   if (u.pathname === "/presets") return sendJson(await listPresets(), res);
   if (u.pathname.startsWith("/preset/save/")) {
     const name = u.pathname.slice("/preset/save/".length);
-    await savePreset(name, params);
+    const chunks = [];
+    for await (const c of req) chunks.push(c);
+    const buf = chunks.length ? Buffer.concat(chunks) : null;
+    await savePreset(name, params, buf);
     return sendJson({ ok: true }, res);
   }
   if (u.pathname.startsWith("/preset/load/")) {

--- a/src/ui/controls-logic.mjs
+++ b/src/ui/controls-logic.mjs
@@ -183,7 +183,25 @@ export function initUI(win, doc, P, send){
     saveBtn.onclick = async () => {
       const name = presetInput?.value.trim() || presetList?.value;
       if (!name) return;
-      await win.fetch(`/preset/save/${encodeURIComponent(name)}`, { method: 'POST' });
+      const left = doc.getElementById('left');
+      const right = doc.getElementById('right');
+      if (left && right){
+        const size = Math.min(left.width, left.height);
+        const off = doc.createElement('canvas');
+        off.width = size * 2;
+        off.height = size;
+        const ctx = off.getContext('2d');
+        ctx.drawImage(left, 0, 0, left.width, left.height, 0, 0, size, size);
+        ctx.drawImage(right, 0, 0, right.width, right.height, size, 0, size, size);
+        const blob = await new Promise(res => off.toBlob(res, 'image/png'));
+        await win.fetch(`/preset/save/${encodeURIComponent(name)}`, {
+          method: 'POST',
+          body: blob,
+          headers: { 'Content-Type': 'image/png' }
+        });
+      } else {
+        await win.fetch(`/preset/save/${encodeURIComponent(name)}`, { method: 'POST' });
+      }
       await refreshPresetDropdown(win, doc, presetList);
       if (presetInput) presetInput.value = name;
     };

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -5,7 +5,7 @@ Browser interface providing live preview and controls.
 - `index.html` – control layout and canvas elements grouped into Effect, General, Orientation, Strobe and Tint sections. Pitch and yaw speed sliders live under Orientation while read-only numeric inputs display their absolute angles in degrees. The effect selector is populated at runtime from the shared effects map.
 - `main.mjs` – entry point for JS logic, wiring modules together, exposes a 'run' function.
 - `connection.mjs` – WebSocket setup and message handling.
-- `controls-logic.mjs` – wires DOM controls to params and renders effect-specific widgets.
+- `controls-logic.mjs` – wires DOM controls to params, renders effect-specific widgets and saves presets with preview thumbnails.
 - `preview-renderer.mjs` – scene generation and drawing, duplicating a single scene to both canvases.
 - `presets.mjs` – handles saving/retreiving configuration and listing the saved options.
 - `subviews/` – reusable widgets and `renderControls` helper.

--- a/test/preset.test.mjs
+++ b/test/preset.test.mjs
@@ -1,12 +1,14 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { savePreset, loadPreset, listPresets } from '../src/config-store.mjs';
-import { unlink } from 'node:fs/promises';
+import { unlink, stat } from 'node:fs/promises';
 import path from 'node:path';
 import url from 'node:url';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const presetPath = path.resolve(__dirname, '../config/presets/test.json');
+const presetImg = path.resolve(__dirname, '../config/presets/test-image.png');
+const presetImgJson = path.resolve(__dirname, '../config/presets/test-image.json');
 
 const sampleParams = {
   fpsCap: 30,
@@ -33,4 +35,16 @@ test('save and load preset', async () => {
   const list = await listPresets();
   assert(list.includes('test'));
   await unlink(presetPath);
+});
+
+test('save preset with image', async () => {
+  const png = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQI12P4//8/AwAI/AL+XJ/kAAAAAElFTkSuQmCC',
+    'base64'
+  );
+  await savePreset('test-image', sampleParams, png);
+  const s = await stat(presetImg);
+  assert(s.size > 0);
+  await unlink(presetImg);
+  await unlink(presetImgJson);
 });

--- a/test/readme.md
+++ b/test/readme.md
@@ -5,7 +5,7 @@ Automated checks for BarnLights Playbox:
 - `engine.test.mjs` – validates engine output and config section lengths.
 - `engine-layout.test.mjs` – ensures layout loading rejects malformed files.
 - `config.test.mjs` – verifies configuration LED totals and section bounds.
-- `preset.test.mjs` – saves and loads effect presets.
+- `preset.test.mjs` – saves and loads effect presets and their preview images.
 - `preset-ui.test.mjs` – ensures the preset dropdown reflects available files.
 - `web.test.mjs` – loads the browser preview and fails on console errors.
 


### PR DESCRIPTION
## Summary
- capture both preview canvases and send thumbnail when saving presets
- store optional preview images alongside preset JSON files
- document preview thumbnail support and test image saving

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae62b843f88322b24be78d334aed71