### PR TITLE
Document NDJSON output contract

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,44 @@ npm start
 npm test
 ```
 
+## Output contract
+
+The engine writes one [NDJSON](https://ndjson.org/) object per rendered frame to
+stdout. Each line represents the color data for all configured sections.
+
+```json
+{
+  "ts": 1714000000,
+  "frame": 0,
+  "fps": 60,
+  "format": "rgb8",
+  "sides": {
+    "left": {
+      "row_A1": { "length": 180, "rgb_b64": "..." },
+      "row_A2": { "length": 120, "rgb_b64": "..." }
+    },
+    "right": {
+      "row_A1": { "length": 200, "rgb_b64": "..." }
+    }
+  }
+}
+```
+
+- `ts` – UNIX timestamp (seconds) when the frame was generated.
+- `frame` – zero-based frame counter.
+- `fps` – frames-per-second cap applied to the render loop.
+- `format` – color encoding; currently `rgb8`, meaning each LED is three bytes
+  `[R,G,B]` with values 0–255.
+- `sides` – object keyed by layout side names such as `left` and `right`. Each
+  side contains an object keyed by layout section IDs. For each section:
+  - `length` – number of LEDs in that section.
+  - `rgb_b64` – base64 string containing `length*3` bytes. Decoding yields
+    `[R0,G0,B0, R1,G1,B1, ...]` following the LED order defined in the layout.
+
+Consumers should read lines individually, parse the JSON, decode `rgb_b64` for
+each section, and map the resulting RGB byte arrays to hardware or downstream
+systems.
+
 ## About the code
 
 ### Architecture


### PR DESCRIPTION
## Summary
- expand README with a new Output contract section documenting the NDJSON frame format with field descriptions and example payload.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae6bcc96348322b4b9f91621442642