### PR TITLE
refactor: render directly to canvas

### DIFF
--- a/src/ui/main.mjs
+++ b/src/ui/main.mjs
@@ -44,7 +44,7 @@ export async function run(docArg = globalThis.document){
     // Build the UI and start rendering frames if canvases are available.
     initUI(win, doc, params, send);
     if (ctxL && ctxR){
-      frame(win, doc, ctxL, ctxR, leftFrame, rightFrame, params, layoutLeft, layoutRight, sceneW, sceneH);
+        frame(win, ctxL, ctxR, leftFrame, rightFrame, params, layoutLeft, layoutRight, sceneW, sceneH);
     } else setStatus(doc, "Preview unavailable");
   };
   const onParams = (m) => {


### PR DESCRIPTION
## Summary
- simplify UI renderer by creating ImageData per frame and drawing directly to canvas
- update frame loop and caller to drop offscreen canvas globals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae6a4066508322a72305cf95044c10