### PR TITLE
feat: add scrollable preset panel

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Minimal Node + browser setup that:
 - samples per your layout JSON into per-row "slices",
 - **emits SLICES_NDJSON to stdout** (one line per frame),
 - serves a **live preview** with a light barn perspective and per-LED colored dots.
-- allows saving and loading effect presets through the UI with a dropdown of saved presets, storing a preview thumbnail with each.
+- allows saving and loading effect presets through the UI with a panel of saved presets, storing a preview thumbnail with each.
 
 ## Architecture
 - `bin/engine.mjs` launches the HTTP server and invokes the engine's `start` function, streaming NDJSON frames.

--- a/src/config-store.mjs
+++ b/src/config-store.mjs
@@ -15,6 +15,26 @@ export async function listPresets(){
   }
 }
 
+export async function listPresetsWithImages(){
+  try {
+    const files = await fs.readdir(PRESET_DIR);
+    const presets = [];
+    for (const f of files){
+      if (!f.endsWith('.json')) continue;
+      const name = f.slice(0, -5);
+      let img = null;
+      try {
+        const buf = await fs.readFile(path.join(PRESET_DIR, `${name}.png`));
+        img = `data:image/png;base64,${buf.toString('base64')}`;
+      } catch {}
+      presets.push({ name, img });
+    }
+    return presets;
+  } catch {
+    return [];
+  }
+}
+
 export async function savePreset(name, params, imageBuf){
   await fs.mkdir(PRESET_DIR, { recursive: true });
   const p = path.join(PRESET_DIR, `${name}.json`);

--- a/src/readme.md
+++ b/src/readme.md
@@ -8,7 +8,7 @@ Core runtime code for BarnLights Playbox:
 - `config-store.mjs` – read/write helpers for saving and loading effect presets and their preview images.
 - `effects/` – effect implementations, registry and post-processing helpers.
 - `ui/` – browser UI for preview and controls, can modify the `params` which the engine renders.
-- `ui/presets.mjs` – helper to fetch preset names and update the UI dropdown.
+- `ui/presets.mjs` – helper to fetch preset data and update the preset panel.
 
 ## A note on the engine's use of effects
 

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -5,7 +5,7 @@ import path from "path";
 import url from "url";
 
 import { params, updateParams, layoutLeft, layoutRight, SCENE_W, SCENE_H } from "./engine.mjs";
-import { savePreset, loadPreset, listPresets } from "./config-store.mjs";
+import { savePreset, loadPreset, listPresetsWithImages } from "./config-store.mjs";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const UI_DIR = path.join(__dirname, "ui");
@@ -47,7 +47,7 @@ const server = http.createServer(async (req, res) => {
   }
   if (u.pathname === "/layout/left") return sendJson(layoutLeft, res);
   if (u.pathname === "/layout/right") return sendJson(layoutRight, res);
-  if (u.pathname === "/presets") return sendJson(await listPresets(), res);
+  if (u.pathname === "/presets") return sendJson(await listPresetsWithImages(), res);
   if (u.pathname.startsWith("/preset/save/")) {
     const name = u.pathname.slice("/preset/save/".length);
     const chunks = [];

--- a/src/ui/controls-logic.mjs
+++ b/src/ui/controls-logic.mjs
@@ -3,7 +3,7 @@ import { effects } from '../effects/index.mjs';
 import { renderControls } from './subviews/index.mjs';
 import { rgbToHex } from './subviews/utils.mjs';
 import { initSpeedSlider } from './subviews/speedSlider.mjs';
-import { refreshPresetDropdown } from './presets.mjs';
+import { refreshPresetPanel } from './presets.mjs';
 
 // Function used to send parameter patches back to the engine
 let sendFn = null;
@@ -195,15 +195,18 @@ export function initUI(win, doc, P, send){
   updateAngles();
 
   const presetInput = doc.getElementById('presetName');
-  const presetList = doc.getElementById('presetList');
-  if (presetList){
-    presetList.onchange = () => { if (presetInput) presetInput.value = presetList.value; };
-    refreshPresetDropdown(win, doc, presetList);
+  const presetPanel = doc.getElementById('presetList');
+  const selectPreset = async (name) => {
+    if (presetInput) presetInput.value = name;
+    await win.fetch(`/preset/load/${encodeURIComponent(name)}`);
+  };
+  if (presetPanel){
+    refreshPresetPanel(win, doc, presetPanel, selectPreset);
   }
   const saveBtn = doc.getElementById('savePreset');
   if (saveBtn){
     saveBtn.onclick = async () => {
-      const name = presetInput?.value.trim() || presetList?.value;
+      const name = presetInput?.value.trim();
       if (!name) return;
       const left = doc.getElementById('left');
       const right = doc.getElementById('right');
@@ -224,16 +227,8 @@ export function initUI(win, doc, P, send){
       } else {
         await win.fetch(`/preset/save/${encodeURIComponent(name)}`, { method: 'POST' });
       }
-      await refreshPresetDropdown(win, doc, presetList);
+      await refreshPresetPanel(win, doc, presetPanel, selectPreset);
       if (presetInput) presetInput.value = name;
-    };
-  }
-  const loadBtn = doc.getElementById('loadPreset');
-  if (loadBtn){
-    loadBtn.onclick = async () => {
-      const name = presetInput?.value.trim() || presetList?.value;
-      if (!name) return;
-      await win.fetch(`/preset/load/${encodeURIComponent(name)}`);
     };
   }
 

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -17,6 +17,9 @@
   #left { transform: rotateY(15deg) skewY(-2deg); }
   #right{ transform: rotateY(-15deg) skewY(2deg);  }
   .panel { display:flex; flex-direction:row; gap:var(--gap); align-items:flex-start; flex-wrap:wrap; }
+  .presets { display:flex; gap:8px; overflow-x:auto; }
+  .preset { display:flex; flex-direction:column; align-items:center; border:none; background:none; padding:0; cursor:pointer; }
+  .preset img { width:64px; height:32px; object-fit:cover; border-radius:4px; }
   .hslider { width:180px; height:20px; position:relative; border:1px solid #ccc; border-radius:10px; background:#f3f3f3; touch-action:none; }
   .hslider .handle { position:absolute; width:12px; height:12px; border-radius:50%; background:#666; top:50%; transform:translate(-50%,-50%); left:50%; }
 </style>
@@ -32,6 +35,15 @@
 </div>
 <div class="panel">
   <fieldset>
+    <legend>Presets</legend>
+    <div class="presets" id="presetList"></div>
+    <div class="row">
+      <input id="presetName" placeholder="name">
+      <button id="savePreset">Save</button>
+    </div>
+  </fieldset>
+
+  <fieldset>
     <legend>Effect</legend>
     <div class="row">
       <label>Effect
@@ -39,16 +51,6 @@
       </label>
     </div>
     <div class="row" id="effectControls"></div>
-  </fieldset>
-
-  <fieldset>
-    <legend>Presets</legend>
-    <div class="row">
-      <input id="presetName" placeholder="name">
-      <select id="presetList"></select>
-      <button id="savePreset">Save</button>
-      <button id="loadPreset">Load</button>
-    </div>
   </fieldset>
 
     <fieldset>

--- a/src/ui/presets.mjs
+++ b/src/ui/presets.mjs
@@ -1,20 +1,27 @@
-export async function fetchPresetNames(win){
+export async function fetchPresets(win){
   const res = await win.fetch('/presets');
   return res.json();
 }
 
-export function populatePresetDropdown(doc, selectEl, names){
-  selectEl.innerHTML = '';
-  names.forEach(n => {
-    const opt = doc.createElement('option');
-    opt.value = n;
-    opt.textContent = n;
-    selectEl.appendChild(opt);
+export function renderPresetPanel(doc, container, presets, onSelect){
+  container.innerHTML = '';
+  presets.forEach(p => {
+    const btn = doc.createElement('button');
+    btn.className = 'preset';
+    const img = doc.createElement('img');
+    if (p.img) img.src = p.img;
+    img.alt = p.name;
+    const label = doc.createElement('span');
+    label.textContent = p.name;
+    btn.appendChild(img);
+    btn.appendChild(label);
+    btn.onclick = () => onSelect(p.name);
+    container.appendChild(btn);
   });
 }
 
-export async function refreshPresetDropdown(win, doc, selectEl){
-  const names = await fetchPresetNames(win);
-  populatePresetDropdown(doc, selectEl, names);
-  return names;
+export async function refreshPresetPanel(win, doc, container, onSelect){
+  const presets = await fetchPresets(win);
+  renderPresetPanel(doc, container, presets, onSelect);
+  return presets;
 }

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -8,5 +8,5 @@ Browser interface providing a live preview above a panel of controls.
 - `connection.mjs` – WebSocket setup and message handling.
 - `controls-logic.mjs` – wires DOM controls to params and renders effect-specific widgets.
 - `renderer.mjs` – uses `renderFrames` to draw the scene for both walls and overlay per-LED indicators.
-- `presets.mjs` – handles saving/retreiving configuration and listing the saved options.
+- `presets.mjs` – handles saving/retrieving configuration and rendering the saved preset panel with thumbnails.
 - `subviews/` – reusable widgets and `renderControls` helper.

--- a/test/preset-ui.test.mjs
+++ b/test/preset-ui.test.mjs
@@ -1,21 +1,30 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { refreshPresetDropdown } from '../src/ui/presets.mjs';
+import { refreshPresetPanel } from '../src/ui/presets.mjs';
 
-test('preset dropdown matches fetched names', async () => {
-  const names = ['one','two'];
-  const win = { fetch: async () => ({ json: async () => names }) };
+test('preset panel matches fetched items', async () => {
+  const items = [{ name: 'one', img: 'a' }, { name: 'two', img: 'b' }];
+  const win = { fetch: async () => ({ json: async () => items }) };
   const doc = {
     createElement(tag){
-      return { tag, value: '', textContent: '', appendChild(){}};
+      return {
+        tag,
+        children: [],
+        className: '',
+        src: '',
+        alt: '',
+        textContent: '',
+        onclick: null,
+        appendChild(child){ this.children.push(child); }
+      };
     }
   };
-  const select = {
+  const container = {
     innerHTML: '',
-    options: [],
-    appendChild(opt){ this.options.push(opt); }
+    children: [],
+    appendChild(el){ this.children.push(el); }
   };
-  await refreshPresetDropdown(win, doc, select);
-  assert.equal(select.options.length, names.length);
-  assert.deepEqual(select.options.map(o => o.value), names);
+  await refreshPresetPanel(win, doc, container, () => {});
+  assert.equal(container.children.length, items.length);
+  assert.deepEqual(container.children.map(c => c.children[1].textContent), items.map(i => i.name));
 });

--- a/test/readme.md
+++ b/test/readme.md
@@ -6,7 +6,7 @@ Automated checks for BarnLights Playbox:
 - `engine-layout.test.mjs` – ensures layout loading rejects malformed files.
 - `config.test.mjs` – verifies configuration LED totals and section bounds.
 - `preset.test.mjs` – saves and loads effect presets and their preview images.
-- `preset-ui.test.mjs` – ensures the preset dropdown reflects available files.
+- `preset-ui.test.mjs` – ensures the preset panel reflects available files.
 - `web.test.mjs` – loads the browser preview and fails on console errors.
 
 The engine exports a `start` function and is invoked via `bin/engine.mjs`, which also launches the HTTP server. Web server and engine can be invoked independently for testing.


### PR DESCRIPTION
## Summary
- show presets as a scrollable panel with thumbnails and save input
- serve preset image data from the server
- update preset logic, tests, and docs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae690213ac8322bef115e1b720bd21