### PR TITLE
feat: show presets as thumbnail panel

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Minimal Node + browser setup that:
 - samples per your layout JSON into per-row "slices",
 - **emits SLICES_NDJSON to stdout** (one line per frame),
 - serves a **live preview** with a light barn perspective and per-LED colored dots.
-- allows saving and loading effect presets through the UI with a dropdown of saved presets, storing a preview thumbnail with each.
+- allows saving and loading effect presets through the UI with a thumbnail panel of saved presets, storing a preview image with each.
 
 ## Architecture
 - `bin/engine.mjs` launches the HTTP server and invokes the engine's `start` function, streaming NDJSON frames.

--- a/src/readme.md
+++ b/src/readme.md
@@ -8,7 +8,7 @@ Core runtime code for BarnLights Playbox:
 - `config-store.mjs` – read/write helpers for saving and loading effect presets and their preview images.
 - `effects/` – effect implementations, registry and post-processing helpers.
 - `ui/` – browser UI for preview and controls, can modify the `params` which the engine renders.
-- `ui/presets.mjs` – helper to fetch preset names and update the UI dropdown.
+- `ui/presets.mjs` – helper to fetch preset names and update the UI panel.
 
 ## A note on the engine's use of effects
 

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -68,6 +68,16 @@ const server = http.createServer(async (req, res) => {
       return;
     }
   }
+  if (u.pathname.startsWith("/preset/preview/")) {
+    const name = decodeURIComponent(u.pathname.slice("/preset/preview/".length));
+    const p = path.join(__dirname, "../config/presets", `${name}.png`);
+    try {
+      return streamFile(p, "image/png", res);
+    } catch {
+      res.writeHead(404).end("Not found");
+      return;
+    }
+  }
   res.writeHead(404).end("Not found");
 });
 

--- a/src/ui/controls-logic.mjs
+++ b/src/ui/controls-logic.mjs
@@ -3,7 +3,7 @@ import { effects } from '../effects/index.mjs';
 import { renderControls } from './subviews/index.mjs';
 import { rgbToHex } from './subviews/utils.mjs';
 import { initSpeedSlider } from './subviews/speedSlider.mjs';
-import { refreshPresetDropdown } from './presets.mjs';
+import { refreshPresetPanel } from './presets.mjs';
 
 // Function used to send parameter patches back to the engine
 let sendFn = null;
@@ -195,15 +195,18 @@ export function initUI(win, doc, P, send){
   updateAngles();
 
   const presetInput = doc.getElementById('presetName');
-  const presetList = doc.getElementById('presetList');
-  if (presetList){
-    presetList.onchange = () => { if (presetInput) presetInput.value = presetList.value; };
-    refreshPresetDropdown(win, doc, presetList);
+  const presetContainer = doc.getElementById('presetList');
+  const loadPreset = async (name) => {
+    await win.fetch(`/preset/load/${encodeURIComponent(name)}`);
+    if (presetInput) presetInput.value = name;
+  };
+  if (presetContainer){
+    refreshPresetPanel(win, doc, presetContainer, loadPreset);
   }
   const saveBtn = doc.getElementById('savePreset');
   if (saveBtn){
     saveBtn.onclick = async () => {
-      const name = presetInput?.value.trim() || presetList?.value;
+      const name = presetInput?.value.trim();
       if (!name) return;
       const left = doc.getElementById('left');
       const right = doc.getElementById('right');
@@ -224,16 +227,8 @@ export function initUI(win, doc, P, send){
       } else {
         await win.fetch(`/preset/save/${encodeURIComponent(name)}`, { method: 'POST' });
       }
-      await refreshPresetDropdown(win, doc, presetList);
+      await refreshPresetPanel(win, doc, presetContainer, loadPreset);
       if (presetInput) presetInput.value = name;
-    };
-  }
-  const loadBtn = doc.getElementById('loadPreset');
-  if (loadBtn){
-    loadBtn.onclick = async () => {
-      const name = presetInput?.value.trim() || presetList?.value;
-      if (!name) return;
-      await win.fetch(`/preset/load/${encodeURIComponent(name)}`);
     };
   }
 

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -17,6 +17,9 @@
   #left { transform: rotateY(15deg) skewY(-2deg); }
   #right{ transform: rotateY(-15deg) skewY(2deg);  }
   .panel { display:flex; flex-direction:row; gap:var(--gap); align-items:flex-start; flex-wrap:wrap; }
+  .presetRow { display:flex; flex-direction:row; gap:10px; overflow-x:auto; }
+  .presetItem { display:flex; flex-direction:column; align-items:center; cursor:pointer; }
+  .presetItem img { width:96px; height:48px; object-fit:cover; border:1px solid #ccc; border-radius:4px; }
   .hslider { width:180px; height:20px; position:relative; border:1px solid #ccc; border-radius:10px; background:#f3f3f3; touch-action:none; }
   .hslider .handle { position:absolute; width:12px; height:12px; border-radius:50%; background:#666; top:50%; transform:translate(-50%,-50%); left:50%; }
 </style>
@@ -32,6 +35,17 @@
 </div>
 <div class="panel">
   <fieldset>
+    <legend>Presets</legend>
+    <div class="row">
+      <div id="presetList" class="presetRow"></div>
+      <div style="display:flex; gap:8px; align-items:center;">
+        <input id="presetName" placeholder="name">
+        <button id="savePreset">Save</button>
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset>
     <legend>Effect</legend>
     <div class="row">
       <label>Effect
@@ -39,16 +53,6 @@
       </label>
     </div>
     <div class="row" id="effectControls"></div>
-  </fieldset>
-
-  <fieldset>
-    <legend>Presets</legend>
-    <div class="row">
-      <input id="presetName" placeholder="name">
-      <select id="presetList"></select>
-      <button id="savePreset">Save</button>
-      <button id="loadPreset">Load</button>
-    </div>
   </fieldset>
 
     <fieldset>

--- a/src/ui/presets.mjs
+++ b/src/ui/presets.mjs
@@ -3,18 +3,25 @@ export async function fetchPresetNames(win){
   return res.json();
 }
 
-export function populatePresetDropdown(doc, selectEl, names){
-  selectEl.innerHTML = '';
+export function renderPresetList(doc, container, names, onSelect){
+  container.innerHTML = '';
   names.forEach(n => {
-    const opt = doc.createElement('option');
-    opt.value = n;
-    opt.textContent = n;
-    selectEl.appendChild(opt);
+    const item = doc.createElement('div');
+    item.className = 'presetItem';
+    const img = doc.createElement('img');
+    img.src = `/preset/preview/${encodeURIComponent(n)}`;
+    img.alt = n;
+    item.appendChild(img);
+    const label = doc.createElement('div');
+    label.textContent = n;
+    item.appendChild(label);
+    item.onclick = () => onSelect(n);
+    container.appendChild(item);
   });
 }
 
-export async function refreshPresetDropdown(win, doc, selectEl){
+export async function refreshPresetPanel(win, doc, container, onSelect){
   const names = await fetchPresetNames(win);
-  populatePresetDropdown(doc, selectEl, names);
+  renderPresetList(doc, container, names, onSelect);
   return names;
 }

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -8,5 +8,5 @@ Browser interface providing a live preview above a panel of controls.
 - `connection.mjs` – WebSocket setup and message handling.
 - `controls-logic.mjs` – wires DOM controls to params and renders effect-specific widgets.
 - `renderer.mjs` – uses `renderFrames` to draw the scene for both walls and overlay per-LED indicators.
-- `presets.mjs` – handles saving/retreiving configuration and listing the saved options.
+- `presets.mjs` – handles saving/retreiving configuration and listing the saved options with thumbnails.
 - `subviews/` – reusable widgets and `renderControls` helper.

--- a/test/preset-ui.test.mjs
+++ b/test/preset-ui.test.mjs
@@ -1,21 +1,29 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { refreshPresetDropdown } from '../src/ui/presets.mjs';
+import { refreshPresetPanel } from '../src/ui/presets.mjs';
 
-test('preset dropdown matches fetched names', async () => {
+test('preset panel matches fetched names', async () => {
   const names = ['one','two'];
   const win = { fetch: async () => ({ json: async () => names }) };
   const doc = {
     createElement(tag){
-      return { tag, value: '', textContent: '', appendChild(){}};
+      return {
+        tag,
+        children: [],
+        className: '',
+        src: '',
+        alt: '',
+        textContent: '',
+        onclick: null,
+        appendChild(child){ this.children.push(child); }
+      };
     }
   };
-  const select = {
+  const container = {
     innerHTML: '',
-    options: [],
-    appendChild(opt){ this.options.push(opt); }
+    children: [],
+    appendChild(child){ this.children.push(child); }
   };
-  await refreshPresetDropdown(win, doc, select);
-  assert.equal(select.options.length, names.length);
-  assert.deepEqual(select.options.map(o => o.value), names);
+  await refreshPresetPanel(win, doc, container, ()=>{});
+  assert.equal(container.children.length, names.length);
 });

--- a/test/readme.md
+++ b/test/readme.md
@@ -6,7 +6,7 @@ Automated checks for BarnLights Playbox:
 - `engine-layout.test.mjs` – ensures layout loading rejects malformed files.
 - `config.test.mjs` – verifies configuration LED totals and section bounds.
 - `preset.test.mjs` – saves and loads effect presets and their preview images.
-- `preset-ui.test.mjs` – ensures the preset dropdown reflects available files.
+- `preset-ui.test.mjs` – ensures the preset panel reflects available files.
 - `web.test.mjs` – loads the browser preview and fails on console errors.
 
 The engine exports a `start` function and is invoked via `bin/engine.mjs`, which also launches the HTTP server. Web server and engine can be invoked independently for testing.


### PR DESCRIPTION
## Summary
- replace preset dropdown with a horizontally scrolling thumbnail panel
- add preset panel rendering helpers and server endpoint for preview images
- update docs and tests for new preset panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae690213ac8322bef115e1b720bd21