### PR TITLE
Add renderFrames test coverage and canvas helper export

### DIFF
--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -7,6 +7,6 @@ Browser interface providing a live preview above a panel of controls.
 - `main.mjs` – entry point for JS logic, wiring modules together, exposes a 'run' function.
 - `connection.mjs` – WebSocket setup and message handling.
 - `controls-logic.mjs` – wires DOM controls to params and renders effect-specific widgets.
-- `renderer.mjs` – uses `renderFrames` to draw the scene for both walls and overlay per-LED indicators.
+- `renderer.mjs` – uses `renderFrames` to draw the scene for both walls and overlay per-LED indicators, and exports `drawSceneToCanvas` for testing.
 - `presets.mjs` – handles saving/retreiving configuration and listing the saved options.
 - `subviews/` – reusable widgets and `renderControls` helper.

--- a/src/ui/renderer.mjs
+++ b/src/ui/renderer.mjs
@@ -1,7 +1,7 @@
 import { sliceSection, clamp01 } from "../effects/modifiers.mjs";
 import { renderFrames } from "../render-scene.mjs";
 
-function drawSceneToCanvas(ctx, sceneF32, sceneW, sceneH){
+export function drawSceneToCanvas(ctx, sceneF32, sceneW, sceneH){
   const img = ctx.createImageData(sceneW, sceneH);
   const dim = 0.75; // dim factor for non-pixel regions
   for (let i = 0, j = 0; i < sceneF32.length; i += 3, j += 4){

--- a/test/readme.md
+++ b/test/readme.md
@@ -8,7 +8,7 @@ Automated checks for BarnLights Playbox:
 - `preset.test.mjs` – saves and loads effect presets and their preview images.
 - `preset-ui.test.mjs` – ensures the preset dropdown reflects available files.
 - `web.test.mjs` – loads the browser preview and fails on console errors.
-- `renderFrames.test.mjs` – verifies frame splitting modes and canvas drawing.
+- `renderFrames.test.mjs` – verifies duplicate, extended, and mirror frame-splitting modes.
 
 The engine exports a `start` function and is invoked via `bin/engine.mjs`, which also launches the HTTP server. Web server and engine can be invoked independently for testing.
 

--- a/test/readme.md
+++ b/test/readme.md
@@ -8,6 +8,7 @@ Automated checks for BarnLights Playbox:
 - `preset.test.mjs` – saves and loads effect presets and their preview images.
 - `preset-ui.test.mjs` – ensures the preset dropdown reflects available files.
 - `web.test.mjs` – loads the browser preview and fails on console errors.
+- `renderFrames.test.mjs` – verifies frame splitting modes and canvas drawing.
 
 The engine exports a `start` function and is invoked via `bin/engine.mjs`, which also launches the HTTP server. Web server and engine can be invoked independently for testing.
 

--- a/test/renderFrames.test.mjs
+++ b/test/renderFrames.test.mjs
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { renderFrames, SCENE_W, SCENE_H } from '../src/render-scene.mjs';
+import { drawSceneToCanvas } from '../src/ui/renderer.mjs';
+
+const baseParams = {
+  effect: 'gradient',
+  effects: {
+    gradient: {
+      stops: [
+        { pos: 0, color: [0, 0, 1] },
+        { pos: 1, color: [1, 0, 0] },
+      ],
+      gradPhase: 0,
+    },
+  },
+  post: {
+    tint: [1, 1, 1],
+    brightness: 1,
+    gamma: 1,
+    strobeHz: 0,
+    strobeDuty: 0.5,
+    strobeLow: 0,
+    pitchSpeed: 0,
+    yawSpeed: 0,
+    pitch: 0,
+    yaw: 0,
+  },
+  renderMode: 'duplicate',
+};
+
+test('extended mode splits gradient across frames', () => {
+  const leftFrame = new Float32Array(SCENE_W * SCENE_H * 3);
+  const rightFrame = new Float32Array(SCENE_W * SCENE_H * 3);
+  const params = { ...baseParams, renderMode: 'extended' };
+  renderFrames(leftFrame, rightFrame, params, 0);
+  assert.notStrictEqual(leftFrame[0], rightFrame[0]);
+});
+
+test('mirror mode reflects last pixel to right frame start', () => {
+  const leftFrame = new Float32Array(SCENE_W * SCENE_H * 3);
+  const rightFrame = new Float32Array(SCENE_W * SCENE_H * 3);
+  const params = { ...baseParams, renderMode: 'mirror' };
+  renderFrames(leftFrame, rightFrame, params, 0);
+  const lastPixelIndex = (SCENE_W - 1) * 3;
+  assert.strictEqual(rightFrame[0], leftFrame[lastPixelIndex]);
+  assert.strictEqual(rightFrame[1], leftFrame[lastPixelIndex + 1]);
+  assert.strictEqual(rightFrame[2], leftFrame[lastPixelIndex + 2]);
+});
+
+test('drawSceneToCanvas maintains separate buffers', () => {
+  class StubContext {
+    constructor(width, height) {
+      this.canvas = { width, height };
+      this.imageData = new Uint8ClampedArray(width * height * 4);
+      this.imageSmoothingEnabled = true;
+    }
+    createImageData(width, height) {
+      return { data: new Uint8ClampedArray(width * height * 4) };
+    }
+    putImageData(img, x, y) {
+      this.imageData.set(img.data);
+    }
+    getImageData(x, y, width, height) {
+      const length = width * height * 4;
+      return { data: this.imageData.slice(0, length) };
+    }
+  }
+  class OffscreenCanvas {
+    constructor(width, height) {
+      this.context2d = new StubContext(width, height);
+    }
+    getContext(type) {
+      return type === '2d' ? this.context2d : null;
+    }
+  }
+  const canvasA = new OffscreenCanvas(1, 1);
+  const canvasB = new OffscreenCanvas(1, 1);
+  const frameA = new Float32Array([1, 0, 0]);
+  const frameB = new Float32Array([0, 1, 0]);
+  drawSceneToCanvas(canvasA.getContext('2d'), frameA, 1, 1);
+  drawSceneToCanvas(canvasB.getContext('2d'), frameB, 1, 1);
+  const pixelsA = canvasA.getContext('2d').getImageData(0, 0, 1, 1).data;
+  const pixelsB = canvasB.getContext('2d').getImageData(0, 0, 1, 1).data;
+  assert.deepStrictEqual(Array.from(pixelsA.slice(0, 3)), [191, 0, 0]);
+  assert.deepStrictEqual(Array.from(pixelsB.slice(0, 3)), [0, 191, 0]);
+});


### PR DESCRIPTION
## Summary
- export `drawSceneToCanvas` for reuse outside the browser renderer
- test `renderFrames` extended/mirror modes and OffscreenCanvas drawing
- document new test and renderer export in readmes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae70facf0883228e7b9733a595e621