### PR TITLE
Add renderFrames test coverage and canvas helper export

### DIFF
--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -7,6 +7,6 @@ Browser interface providing a live preview above a panel of controls.
 - `main.mjs` – entry point for JS logic, wiring modules together, exposes a 'run' function.
 - `connection.mjs` – WebSocket setup and message handling.
 - `controls-logic.mjs` – wires DOM controls to params and renders effect-specific widgets.
-- `renderer.mjs` – uses `renderFrames` to draw the scene for both walls and overlay per-LED indicators.
+- `renderer.mjs` – uses `renderFrames` to draw the scene for both walls and overlay per-LED indicators, and exports `drawSceneToCanvas` for testing.
 - `presets.mjs` – handles saving/retreiving configuration and listing the saved options.
 - `subviews/` – reusable widgets and `renderControls` helper.

--- a/src/ui/renderer.mjs
+++ b/src/ui/renderer.mjs
@@ -1,7 +1,7 @@
 import { sliceSection, clamp01 } from "../effects/modifiers.mjs";
 import { renderFrames } from "../render-scene.mjs";
 
-function drawSceneToCanvas(ctx, sceneF32, sceneW, sceneH){
+export function drawSceneToCanvas(ctx, sceneF32, sceneW, sceneH){
   const img = ctx.createImageData(sceneW, sceneH);
   const dim = 0.75; // dim factor for non-pixel regions
   for (let i = 0, j = 0; i < sceneF32.length; i += 3, j += 4){

--- a/test/readme.md
+++ b/test/readme.md
@@ -8,6 +8,7 @@ Automated checks for BarnLights Playbox:
 - `preset.test.mjs` – saves and loads effect presets and their preview images.
 - `preset-ui.test.mjs` – ensures the preset dropdown reflects available files.
 - `web.test.mjs` – loads the browser preview and fails on console errors.
+- `renderFrames.test.mjs` – verifies duplicate, extended, and mirror frame-splitting modes.
 
 The engine exports a `start` function and is invoked via `bin/engine.mjs`, which also launches the HTTP server. Web server and engine can be invoked independently for testing.
 

--- a/test/renderFrames.test.mjs
+++ b/test/renderFrames.test.mjs
@@ -1,0 +1,76 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { renderFrames, SCENE_W, SCENE_H } from '../src/render-scene.mjs';
+
+const baseParams = {
+  effect: 'gradient',
+  effects: {
+    gradient: {
+      stops: [
+        { pos: 0, color: [0, 0, 1] },
+        { pos: 1, color: [1, 0, 0] },
+      ],
+      gradPhase: 0,
+    },
+  },
+  post: {
+    tint: [1, 1, 1],
+    brightness: 1,
+    gamma: 1,
+    strobeHz: 0,
+    strobeDuty: 0.5,
+    strobeLow: 0,
+    pitchSpeed: 0,
+    yawSpeed: 0,
+    pitch: 0,
+    yaw: 0,
+  },
+  renderMode: 'duplicate',
+};
+
+function assertGradientEdges(frameBuffer) {
+  const firstPixel = [frameBuffer[0], frameBuffer[1], frameBuffer[2]];
+  const lastIndex = (SCENE_W - 1) * 3;
+  const lastPixel = [
+    frameBuffer[lastIndex],
+    frameBuffer[lastIndex + 1],
+    frameBuffer[lastIndex + 2],
+  ];
+  assert.notDeepStrictEqual(firstPixel, lastPixel);
+  return { firstPixel, lastPixel };
+}
+
+test('extended mode splits gradient across frames', () => {
+  const leftFrame = new Float32Array(SCENE_W * SCENE_H * 3);
+  const rightFrame = new Float32Array(SCENE_W * SCENE_H * 3);
+  const params = { ...baseParams, renderMode: 'extended' };
+  renderFrames(leftFrame, rightFrame, params, 0);
+  assertGradientEdges(leftFrame);
+  assertGradientEdges(rightFrame);
+  assert.notStrictEqual(leftFrame[0], rightFrame[0]);
+});
+
+test('mirror mode reflects frame ends', () => {
+  const leftFrame = new Float32Array(SCENE_W * SCENE_H * 3);
+  const rightFrame = new Float32Array(SCENE_W * SCENE_H * 3);
+  const params = { ...baseParams, renderMode: 'mirror' };
+  renderFrames(leftFrame, rightFrame, params, 0);
+  const leftEdges = assertGradientEdges(leftFrame);
+  const rightEdges = assertGradientEdges(rightFrame);
+  assert.deepStrictEqual(rightEdges.firstPixel, leftEdges.lastPixel);
+  assert.deepStrictEqual(rightEdges.lastPixel, leftEdges.firstPixel);
+});
+
+test('duplicate mode copies gradient to both frames', () => {
+  const leftFrame = new Float32Array(SCENE_W * SCENE_H * 3);
+  const rightFrame = new Float32Array(SCENE_W * SCENE_H * 3);
+  renderFrames(leftFrame, rightFrame, baseParams, 0);
+  assertGradientEdges(leftFrame);
+  assertGradientEdges(rightFrame);
+  const lastIndex = (SCENE_W - 1) * 3;
+  assert.strictEqual(leftFrame[0], rightFrame[0]);
+  assert.strictEqual(leftFrame[1], rightFrame[1]);
+  assert.strictEqual(leftFrame[lastIndex], rightFrame[lastIndex]);
+  assert.strictEqual(leftFrame[lastIndex + 1], rightFrame[lastIndex + 1]);
+});
+


### PR DESCRIPTION
## Summary
- export `drawSceneToCanvas` for reuse outside the browser renderer
- test `renderFrames` duplicate, extended, and mirror modes, using a shared gradient guard helper
- document new test suite entry

## Testing
- `sudo apt-get install -y libatk1.0-0 libatk-bridge2.0-0 libcups2t64 libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libasound2t64`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae70facf0883228e7b9733a595e621