### PR TITLE
Overwrite existing presets when saving by name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Minimal Node + browser setup that:
 - samples per your layout JSON into per-row "slices",
 - **emits SLICES_NDJSON to stdout** (one line per frame),
 - serves a **live preview** with a light barn perspective and per-LED colored dots.
-- allows saving and loading effect presets through the UI with a thumbnail panel of saved presets, storing a preview image with each.
+- allows saving and loading effect presets through the UI with a thumbnail panel of saved presets, storing a preview image with each. Saving with an existing name replaces the previous preset.
 
 ## Quick start
 1. Open your terminal

--- a/src/config-store.mjs
+++ b/src/config-store.mjs
@@ -18,6 +18,7 @@ export async function listPresets(){
 export async function savePreset(name, params, imageBuf){
   await fs.mkdir(PRESET_DIR, { recursive: true });
   const presetPath = path.join(PRESET_DIR, `${name}.json`);
+  const imagePath = path.join(PRESET_DIR, `${name}.png`);
 
   const effectId = params.effect;
   const effectParams = params.effects?.[effectId] || {};
@@ -31,8 +32,13 @@ export async function savePreset(name, params, imageBuf){
 
   await fs.writeFile(presetPath, JSON.stringify(presetData, null, 2), "utf8");
   if (imageBuf){
-    const imagePath = path.join(PRESET_DIR, `${name}.png`);
     await fs.writeFile(imagePath, imageBuf);
+  } else {
+    try {
+      await fs.unlink(imagePath);
+    } catch {
+      // ignore if image did not previously exist
+    }
   }
 }
 

--- a/src/readme.md
+++ b/src/readme.md
@@ -5,7 +5,7 @@ Core runtime code for BarnLights Playbox:
 - `render-scene.mjs` – shared scene rendering, post-processing and `renderFrames` helper for mapping scenes to both walls.
 - `engine.mjs` – side‑effect‑free render loop using `renderFrames` and exposing `params` (including `renderMode`); call `start()` to emit SLICES_NDJSON.
 - `server.mjs` – HTTP/WebSocket server serving the UI and applying param updates.
-- `config-store.mjs` – read/write helpers for saving only the active effect's preset and shared parameters; loading merges only values present in the preset JSON. Preview images are stored alongside presets.
+- `config-store.mjs` – read/write helpers for saving only the active effect's preset and shared parameters; loading merges only values present in the preset JSON. Preview images are stored alongside presets. Saving with a duplicate name replaces the previous preset and its preview image.
 - `effects/` – effect implementations, registry and post-processing helpers.
 - `ui/` – browser UI for preview and controls, can modify the `params` which the engine renders.
 - `ui/presets.mjs` – helper to fetch preset names and update the UI panel.

--- a/test/preset.test.mjs
+++ b/test/preset.test.mjs
@@ -84,3 +84,26 @@ test('save preset with image', async () => {
   await unlink(presetImg);
   await unlink(presetImgJson);
 });
+
+test('saving preset overwrites existing data and images', async () => {
+  const png = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQI12P4//8/AwAI/AL+XJ/kAAAAAElFTkSuQmCC',
+    'base64'
+  );
+  const overwritePath = path.resolve(__dirname, '../config/presets/overwrite.json');
+  const overwriteImg = path.resolve(__dirname, '../config/presets/overwrite.png');
+
+  await savePreset('overwrite', sampleParams, png);
+
+  const updatedParams = { ...sampleParams, fpsCap: 45 };
+  await savePreset('overwrite', updatedParams);
+
+  const loaded = await loadPreset('overwrite');
+  assert.equal(loaded.fpsCap, 45);
+  await assert.rejects(stat(overwriteImg));
+
+  await unlink(overwritePath);
+  try {
+    await unlink(overwriteImg);
+  } catch {}
+});


### PR DESCRIPTION
## Summary
- Overwrite existing preset files and remove old preview images when saving with a duplicate name.
- Document preset overwrite behavior in project and source module READMEs.
- Add a regression test verifying preset data and image replacement.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae9228d198832289a08a9ea6aa5335