### PR TITLE
feat: render preview with React

### DIFF
--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -2,11 +2,14 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { run } from './main.mjs';
 import { WebSocketProvider } from './WebSocketContext.js';
 import { ParamsProvider } from './ParamsContext.js';
+import Renderer from './Renderer.jsx';
 
 export default function App() {
   const [handlers, setHandlers] = useState(null);
   const [sendFunction, setSendFunction] = useState(() => {});
   const [runtime, setRuntime] = useState(null);
+  const [layouts, setLayouts] = useState({ left: null, right: null });
+  const [scene, setScene] = useState({ width: 0, height: 0 });
 
   const handleReady = useCallback((runtimeValue) => {
     setRuntime(runtimeValue);
@@ -14,7 +17,10 @@ export default function App() {
 
   useEffect(() => {
     if (runtime) {
-      run(runtime.applyLocal, runtime.getParams).then(setHandlers);
+      run(runtime.applyLocal, setScene).then(result => {
+        setHandlers(result);
+        setLayouts({ left: result.layoutLeft, right: result.layoutRight });
+      });
     }
   }, [runtime]);
 
@@ -27,7 +33,15 @@ export default function App() {
   return (
     <ParamsProvider send={sendFunction} onReady={handleReady}>
       <WebSocketProvider onInit={onInit} onParams={onParams} onError={onStatus} setSend={setSendFunction}>
-        {null}
+        {runtime && layouts.left && layouts.right && scene.width && scene.height ? (
+          <Renderer
+            getParams={runtime.getParams}
+            layoutLeft={layouts.left}
+            layoutRight={layouts.right}
+            sceneWidth={scene.width}
+            sceneHeight={scene.height}
+          />
+        ) : null}
       </WebSocketProvider>
     </ParamsProvider>
   );

--- a/src/ui/Renderer.jsx
+++ b/src/ui/Renderer.jsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useRef } from 'react';
+import { renderFrame } from './renderer.mjs';
+
+export default function Renderer({ getParams, layoutLeft, layoutRight, sceneWidth, sceneHeight }) {
+  const canvasLeftRef = useRef(null);
+  const canvasRightRef = useRef(null);
+
+  useEffect(() => {
+    if (!sceneWidth || !sceneHeight) return;
+    const canvasLeft = canvasLeftRef.current;
+    const canvasRight = canvasRightRef.current;
+    if (!canvasLeft || !canvasRight) return;
+
+    const contextLeft = canvasLeft.getContext('2d');
+    const contextRight = canvasRight.getContext('2d');
+    const leftFrame = new Float32Array(sceneWidth * sceneHeight * 3);
+    const rightFrame = new Float32Array(sceneWidth * sceneHeight * 3);
+    let frameRequest = 0;
+    const win = canvasLeft.ownerDocument.defaultView || window;
+
+    const loop = () => {
+      renderFrame(win, contextLeft, contextRight, leftFrame, rightFrame, getParams, layoutLeft, layoutRight, sceneWidth, sceneHeight);
+      frameRequest = win.requestAnimationFrame(loop);
+    };
+    frameRequest = win.requestAnimationFrame(loop);
+
+    return () => {
+      if (frameRequest) win.cancelAnimationFrame(frameRequest);
+    };
+  }, [getParams, layoutLeft, layoutRight, sceneWidth, sceneHeight]);
+
+  return (
+    <div className="barn">
+      <canvas id="left" ref={canvasLeftRef} width="512" height="128"></canvas>
+      <canvas id="right" ref={canvasRightRef} width="512" height="128"></canvas>
+    </div>
+  );
+}
+

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -29,10 +29,7 @@
 
   <h1>BarnLights Playbox</h1>
   <div id="status"></div>
-<div class="barn">
-  <canvas id="left"  width="512" height="128"></canvas>
-  <canvas id="right" width="512" height="128"></canvas>
-</div>
+<div id="root"></div>
 <div class="panel">
   <fieldset>
     <legend>Presets</legend>
@@ -104,5 +101,3 @@
   </fieldset>
 
 </div>
-
-<div id="root"></div>

--- a/src/ui/main.mjs
+++ b/src/ui/main.mjs
@@ -1,4 +1,4 @@
-import { frame } from "./renderer.mjs";
+// Rendering is handled by a React component; this module only manages layout and handlers.
 
 function setStatus(doc, msg){
   const el = doc.getElementById("status");
@@ -15,7 +15,7 @@ async function loadLightLayout(win, doc, side){
   }
 }
 
-export async function run(applyLocal, getParams, docArg = globalThis.document){
+export async function run(applyLocal, setSceneInfo, docArg = globalThis.document){
   const doc = docArg;
   const win = docArg.defaultView || globalThis;
 
@@ -24,20 +24,9 @@ export async function run(applyLocal, getParams, docArg = globalThis.document){
     loadLightLayout(win, doc, "right")
   ]);
 
-  const canvL = doc.getElementById("left");
-  const ctxL = canvL.getContext("2d");
-  const canvR = doc.getElementById("right");
-  const ctxR = canvR.getContext("2d");
-
   const onInit = (msg) => {
     applyLocal(msg.params);
-    const sceneWidth = msg.scene.w;
-    const sceneHeight = msg.scene.h;
-    const leftFrame  = new Float32Array(sceneWidth * sceneHeight * 3);
-    const rightFrame = new Float32Array(sceneWidth * sceneHeight * 3);
-    if (ctxL && ctxR){
-        frame(win, ctxL, ctxR, leftFrame, rightFrame, getParams, layoutLeft, layoutRight, sceneWidth, sceneHeight);
-    } else setStatus(doc, "Preview unavailable");
+    setSceneInfo({ width: msg.scene.w, height: msg.scene.h });
   };
 
   const onParams = (msg) => {
@@ -46,5 +35,5 @@ export async function run(applyLocal, getParams, docArg = globalThis.document){
 
   const onStatus = (statusMessage) => setStatus(doc, statusMessage);
 
-  return { onInit, onParams, onStatus };
+  return { onInit, onParams, onStatus, layoutLeft, layoutRight };
 }

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -3,14 +3,15 @@
 Browser interface providing a live preview above a panel of controls.
 
 
-- `index.html` – UI control layout and visual effect preview.
-- `main.mjs` – entry point for JS logic, wiring modules together, exposes a `run` function that updates state through dispatches.
+- `index.html` – UI control layout and React mount point for the preview.
+- `main.mjs` – fetches layouts and exposes handlers used by the React app.
 - `App.jsx` – top-level React component that invokes `run` and provides context.
+- `Renderer.jsx` – React component rendering preview canvases and driving the frame loop.
 - `main.jsx` – React entry rendering `<App />`.
 - `useWebSocket.js` – React hook for managing WebSocket connections.
 - `WebSocketContext.js` – context provider exposing the connection to components.
 - `ParamsContext.js` – React context backed by a `useReducer` hook mirroring the runtime parameter object. Dispatching patches updates state and sends them over the WebSocket.
-- `renderer.mjs` – uses `renderFrames` to draw the scene for both walls and overlay per-LED indicators.
+- `renderer.mjs` – draws a single frame for both walls and overlays per‑LED indicators.
 - `presets.mjs` – handles saving/retreiving configuration and listing the saved options with thumbnails.
 - `subviews/` – reusable widgets and `renderControls` helper.
 

--- a/src/ui/renderer.mjs
+++ b/src/ui/renderer.mjs
@@ -43,7 +43,7 @@ function drawSectionsToCanvas(ctx, sceneF32, layout, sceneW, sceneH){
 }
 
 // frame: render once, draw to both previews, then schedule the next loop
-export function frame(
+export function renderFrame(
   win,
   ctxL, ctxR,
   leftFrame, rightFrame,
@@ -58,5 +58,4 @@ export function frame(
   if (layoutLeft) drawSectionsToCanvas(ctxL, leftFrame, layoutLeft, sceneW, sceneH);
   drawSceneToCanvas(ctxR, rightFrame, sceneW, sceneH);
   if (layoutRight) drawSectionsToCanvas(ctxR, rightFrame, layoutRight, sceneW, sceneH);
-  win.requestAnimationFrame(() => frame(win, ctxL, ctxR, leftFrame, rightFrame, getParams, layoutLeft, layoutRight, sceneW, sceneH));
 }


### PR DESCRIPTION
## Summary
- replace static canvases with a `<Renderer>` React component that drives the frame loop
- expose single-frame `renderFrame` helper and fetch layouts separately
- adjust app initialization for new renderer and document the UI changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeabe2da908322bad6cb31b1ef6c4a