### PR TITLE
Serve built UI bundle

### DIFF
--- a/src/readme.md
+++ b/src/readme.md
@@ -4,7 +4,7 @@ Core runtime code for BarnLights Playbox:
 
 - `render-scene.mjs` – shared scene rendering, post-processing and `renderFrames` helper for mapping scenes to both walls.
 - `engine.mjs` – side‑effect‑free render loop using `renderFrames` and exposing `params` (including `renderMode`); call `start()` to emit SLICES_NDJSON.
-- `server.mjs` – HTTP/WebSocket server serving the UI and applying param updates.
+- `server.mjs` – HTTP/WebSocket server serving the pre-built UI (`ui/dist/index.html` and `bundle.js`) and applying param updates.
 - `config-store.mjs` – read/write helpers for saving only the active effect's preset and shared parameters; loading merges only values present in the preset JSON. Preview images are stored alongside presets. Saving with a duplicate name replaces the previous preset and its preview image.
 - `effects/` – effect implementations, registry and post-processing helpers.
 - `ui/` – browser UI for preview and controls, can modify the `params` which the engine renders.

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -9,20 +9,22 @@ import { savePreset, loadPreset, listPresets } from "./config-store.mjs";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const UI_DIR = path.join(__dirname, "ui");
+const UI_DIST_DIR = path.join(UI_DIR, "dist");
 
 function streamFile(p, mime, res){
   const s = createReadStream(p);
-  res.writeHead(200, { "Content-Type": mime });
+  res.writeHead(200, { "Content-Type": mime, "Connection": "close" });
   s.pipe(res);
 }
 function sendJson(obj, res){
   const buf = Buffer.from(JSON.stringify(obj));
-  res.writeHead(200, { "Content-Type": "application/json" }).end(buf);
+  res.writeHead(200, { "Content-Type": "application/json", "Connection": "close" }).end(buf);
 }
 
 const server = http.createServer(async (req, res) => {
   const u = new URL(req.url, "http://x/");
-  if (u.pathname === "/") return streamFile(path.join(UI_DIR, "index.html"), "text/html", res);
+  if (u.pathname === "/") return streamFile(path.join(UI_DIST_DIR, "index.html"), "text/html", res);
+  if (u.pathname === "/bundle.js") return streamFile(path.join(UI_DIST_DIR, "bundle.js"), "text/javascript", res);
   if (u.pathname === "/preview.mjs") return streamFile(path.join(UI_DIR, "preview.mjs"), "text/javascript", res);
   if (u.pathname === "/main.mjs") return streamFile(path.join(UI_DIR, "main.mjs"), "text/javascript", res);
   if (u.pathname === "/presets.mjs") return streamFile(path.join(UI_DIR, "presets.mjs"), "text/javascript", res);

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -1,56 +1,58 @@
 <!doctype html>
-<meta charset="utf-8" />
-<title>BarnLights Playbox</title>
-<style>
-  :root { --gap: 20px; }
-  body { font: 14px system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 20px; color:#111; }
-  h1 { margin: 0 0 8px; font-size: 20px; }
-  .row { display:flex; flex-direction:column; gap: var(--gap); align-items:flex-start; margin: 6px 0; }
-  label { display:flex; align-items:center; gap:8px; min-width: 220px; }
-  input[type="range"] { width: 180px; }
-  select { padding: 4px 6px; }
-  fieldset { border:1px solid #ccc; padding:10px 14px; margin:0; }
-  legend { padding:0 6px; font-weight:bold; }
-  .desc { font-size:12px; color:#555; }
-  .barn { display:flex; gap: 32px; perspective: 900px; margin:16px auto; justify-content:center; }
-  canvas { width: 512px; height: 128px; image-rendering: pixelated; border-radius: 10px; box-shadow: 0 10px 30px rgba(0,0,0,.25); background:#000; }
-  #left { transform: rotateY(15deg) skewY(-2deg); }
-  #right{ transform: rotateY(-15deg) skewY(2deg);  }
-  .panel { display:flex; flex-direction:row; gap:var(--gap); align-items:flex-start; flex-wrap:wrap; }
-  .presetRow { display:flex; flex-direction:row; gap:10px; overflow-x:auto; }
-  .presetItem { display:flex; flex-direction:column; align-items:center; cursor:pointer; }
-  .presetItem img { width:96px; height:48px; object-fit:cover; border:1px solid #ccc; border-radius:4px; }
-  .hslider { width:180px; height:20px; position:relative; border:1px solid #ccc; border-radius:10px; background:#f3f3f3; touch-action:none; }
-  .hslider .handle { position:absolute; width:12px; height:12px; border-radius:50%; background:#666; top:50%; transform:translate(-50%,-50%); left:50%; }
-</style>
-
-<link rel="stylesheet" href="/vendor/grapick/dist/grapick.min.css">
-<script src="/vendor/grapick/dist/grapick.min.js"></script>
-
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>BarnLights Playbox</title>
+  <style>
+    :root { --gap: 20px; }
+    body { font: 14px system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 20px; color:#111; }
+    h1 { margin: 0 0 8px; font-size: 20px; }
+    .row { display:flex; flex-direction:column; gap: var(--gap); align-items:flex-start; margin: 6px 0; }
+    label { display:flex; align-items:center; gap:8px; min-width: 220px; }
+    input[type="range"] { width: 180px; }
+    select { padding: 4px 6px; }
+    fieldset { border:1px solid #ccc; padding:10px 14px; margin:0; }
+    legend { padding:0 6px; font-weight:bold; }
+    .desc { font-size:12px; color:#555; }
+    .barn { display:flex; gap: 32px; perspective: 900px; margin:16px auto; justify-content:center; }
+    canvas { width: 512px; height: 128px; image-rendering: pixelated; border-radius: 10px; box-shadow: 0 10px 30px rgba(0,0,0,.25); background:#000; }
+    #left { transform: rotateY(15deg) skewY(-2deg); }
+    #right{ transform: rotateY(-15deg) skewY(2deg);  }
+    .panel { display:flex; flex-direction:row; gap:var(--gap); align-items:flex-start; flex-wrap:wrap; }
+    .presetRow { display:flex; flex-direction:row; gap:10px; overflow-x:auto; }
+    .presetItem { display:flex; flex-direction:column; align-items:center; cursor:pointer; }
+    .presetItem img { width:96px; height:48px; object-fit:cover; border:1px solid #ccc; border-radius:4px; }
+    .hslider { width:180px; height:20px; position:relative; border:1px solid #ccc; border-radius:10px; background:#f3f3f3; touch-action:none; }
+    .hslider .handle { position:absolute; width:12px; height:12px; border-radius:50%; background:#666; top:50%; transform:translate(-50%,-50%); left:50%; }
+  </style>
+  <link rel="stylesheet" href="/vendor/grapick/dist/grapick.min.css">
+  <script src="/vendor/grapick/dist/grapick.min.js"></script>
+</head>
+<body>
   <h1>BarnLights Playbox</h1>
   <div id="status"></div>
-<div id="root"></div>
-<div class="panel">
-  <fieldset>
-    <legend>Presets</legend>
-    <div class="row">
-      <div id="presetList" class="presetRow"></div>
-      <div style="display:flex; gap:8px; align-items:center;">
-        <input id="presetName" placeholder="name">
-        <button id="savePreset">Save</button>
+  <div id="root"></div>
+  <div class="panel">
+    <fieldset>
+      <legend>Presets</legend>
+      <div class="row">
+        <div id="presetList" class="presetRow"></div>
+        <div style="display:flex; gap:8px; align-items:center;">
+          <input id="presetName" placeholder="name">
+          <button id="savePreset">Save</button>
+        </div>
       </div>
-    </div>
-  </fieldset>
+    </fieldset>
 
-  <fieldset>
-    <legend>Effect</legend>
-    <div class="row">
-      <label>Effect
-        <select id="effect"></select>
-      </label>
-    </div>
-    <div class="row" id="effectControls"></div>
-  </fieldset>
+    <fieldset>
+      <legend>Effect</legend>
+      <div class="row">
+        <label>Effect
+          <select id="effect"></select>
+        </label>
+      </div>
+      <div class="row" id="effectControls"></div>
+    </fieldset>
 
     <fieldset>
       <legend>General</legend>
@@ -59,12 +61,12 @@
         <label>Gamma <input id="gamma" type="range" min="0.5" max="3" step="0.01"><span id="gamma_v"></span><small class="desc">brightness curve</small></label>
         <label>FPS cap <input id="fpsCap" type="range" min="1" max="60" step="1"><span id="fpsCap_v"></span></label>
         <label>Render mode
-        <select id="renderMode">
-          <option value="duplicate">duplicate</option>
-          <option value="extended">extended</option>
-          <option value="mirror">mirror</option>
-        </select>
-      </label>
+          <select id="renderMode">
+            <option value="duplicate">duplicate</option>
+            <option value="extended">extended</option>
+            <option value="mirror">mirror</option>
+          </select>
+        </label>
       </div>
     </fieldset>
 
@@ -82,22 +84,24 @@
       </div>
     </fieldset>
 
-  <fieldset>
-    <legend>Strobe</legend>
-    <div class="row">
-      <label>Strobe Hz <input id="strobeHz" type="range" min="0" max="20" step="0.1"><span id="strobeHz_v"></span></label>
-      <label>Duty <input id="strobeDuty" type="range" min="0" max="1" step="0.01"><span id="strobeDuty_v"></span><small class="desc">on-time %</small></label>
-      <label>Low <input id="strobeLow" type="range" min="0" max="1" step="0.01"><span id="strobeLow_v"></span><small class="desc">min brightness</small></label>
-    </div>
-  </fieldset>
+    <fieldset>
+      <legend>Strobe</legend>
+      <div class="row">
+        <label>Strobe Hz <input id="strobeHz" type="range" min="0" max="20" step="0.1"><span id="strobeHz_v"></span></label>
+        <label>Duty <input id="strobeDuty" type="range" min="0" max="1" step="0.01"><span id="strobeDuty_v"></span><small class="desc">on-time %</small></label>
+        <label>Low <input id="strobeLow" type="range" min="0" max="1" step="0.01"><span id="strobeLow_v"></span><small class="desc">min brightness</small></label>
+      </div>
+    </fieldset>
 
-  <fieldset>
-    <legend>Tint</legend>
-    <div class="row">
-      <label>Tint R <input id="tintR" type="range" min="0" max="1" step="0.01"><span id="tintR_v"></span></label>
-      <label>Tint G <input id="tintG" type="range" min="0" max="1" step="0.01"><span id="tintG_v"></span></label>
-      <label>Tint B <input id="tintB" type="range" min="0" max="1" step="0.01"><span id="tintB_v"></span></label>
-    </div>
-  </fieldset>
+    <fieldset>
+      <legend>Tint</legend>
+      <div class="row">
+        <label>Tint R <input id="tintR" type="range" min="0" max="1" step="0.01"><span id="tintR_v"></span></label>
+        <label>Tint G <input id="tintG" type="range" min="0" max="1" step="0.01"><span id="tintG_v"></span></label>
+        <label>Tint B <input id="tintB" type="range" min="0" max="1" step="0.01"><span id="tintB_v"></span></label>
+      </div>
+    </fieldset>
+  </div>
+</body>
+</html>
 
-</div>

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -16,3 +16,4 @@ Browser interface providing a live preview above a panel of controls.
 - `subviews/` – reusable widgets and `renderControls` helper.
 
 The UI is bundled with Webpack, treating this directory as the source and writing output to `dist/`.
+The generated `index.html` references the compiled bundle with `<script src="/bundle.js"></script>`.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ export default {
   output: {
     filename: 'bundle.js',
     path: resolve(currentDirectory, 'src/ui/dist'),
+    publicPath: '/',
     clean: true
   },
   resolve: {
@@ -31,7 +32,8 @@ export default {
   },
   plugins: [
     new HtmlWebpackPlugin({
-      template: resolve(currentDirectory, 'src/ui/index.html')
+      template: resolve(currentDirectory, 'src/ui/index.html'),
+      scriptLoading: 'blocking'
     })
   ]
 };


### PR DESCRIPTION
## Summary
- Serve pre-built UI from `dist/index.html` and add route for `/bundle.js`
- Configure Webpack to emit bundle at root path and inject `<script src="/bundle.js"></script>`
- Restructure UI HTML template for bundling and document bundled script

## Testing
- `npm run build:ui`
- `npm test` *(fails: Navigation timeout of 30000 ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb19682108322b7a8ac84880be6f5