### PR TITLE
feat: cache canvas image data

### DIFF
--- a/src/ui/Renderer.jsx
+++ b/src/ui/Renderer.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { renderFrame } from './renderer.mjs';
+import { renderFrame, clearImageCaches } from './renderer.mjs';
 
 export default function Renderer({ getParams, layoutLeft, layoutRight, sceneWidth, sceneHeight }) {
   const canvasLeftRef = useRef(null);
@@ -26,6 +26,7 @@ export default function Renderer({ getParams, layoutLeft, layoutRight, sceneWidt
 
     return () => {
       if (frameRequest) win.cancelAnimationFrame(frameRequest);
+      clearImageCaches();
     };
   }, [getParams, layoutLeft, layoutRight, sceneWidth, sceneHeight]);
 


### PR DESCRIPTION
## Summary
- cache ImageData objects for left and right canvases to avoid per-frame allocation
- reuse cached buffers when drawing and clear them on component unmount

## Testing
- `npm test` *(fails: server not responding)*

------
https://chatgpt.com/codex/tasks/task_e_68aebf740e1c8322a3fee780bd26f389