### PR TITLE
feat: allow skipping browser console test

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@ npm start
 ```bash
 npm test
 ```
+Set `BARN_LIGHTS_SKIP_WEB_TEST=1` to skip the browser preview test when running in environments without browser support.
 
 ## Output contract
 

--- a/test/readme.md
+++ b/test/readme.md
@@ -7,7 +7,7 @@ Automated checks for BarnLights Playbox:
 - `config.test.mjs` – verifies configuration LED totals and section bounds.
 - `preset.test.mjs` – saves and loads effect presets and their preview images.
 - `preset-ui.test.mjs` – ensures the preset panel reflects available files.
-- `web.test.mjs` – loads the browser preview and fails on console errors.
+- `web.test.mjs` – loads the browser preview and fails on console errors. Set `BARN_LIGHTS_SKIP_WEB_TEST=1` to skip this check when browser dependencies are missing.
 - `renderFrames.test.mjs` – verifies duplicate, extended, and mirror frame-splitting modes.
 - `gradient.test.mjs` – confirms the gradient effect can reverse direction.
 - `noise.test.mjs` – ensures the noise effect honors custom gradient stops.

--- a/test/web.test.mjs
+++ b/test/web.test.mjs
@@ -6,6 +6,8 @@ import { fileURLToPath } from 'url';
 import puppeteer from 'puppeteer';
 
 const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const shouldSkipWebConsoleTest = process.env.BARN_LIGHTS_SKIP_WEB_TEST === '1';
+const maybeSkip = shouldSkipWebConsoleTest ? test.skip : test;
 
 async function waitForServer(url, retries = 100){
   for (let i = 0; i < retries; i++) {
@@ -18,7 +20,7 @@ async function waitForServer(url, retries = 100){
   throw new Error('server not responding');
 }
 
-test('web view loads with no console errors', async () => {
+maybeSkip('web view loads with no console errors', async () => {
   const proc = spawn('node', ['bin/engine.mjs'], {
     cwd: ROOT,
     stdio: ['ignore', 'ignore', 'pipe']


### PR DESCRIPTION
## Summary
- Add `BARN_LIGHTS_SKIP_WEB_TEST` env flag so `web.test.mjs` can be skipped in environments without browser support
- Document the new flag in the root and test READMEs

## Testing
- `BARN_LIGHTS_SKIP_WEB_TEST=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeb3f80a808322bf8673c79c9c8055