### PR TITLE
Ensure engine starts with clean NDJSON stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "node bin/engine.mjs",
     "test": "node --test --test-concurrency=1",
     "build:ui": "webpack"
   },

--- a/readme.md
+++ b/readme.md
@@ -14,8 +14,9 @@ Minimal Node + browser setup that:
 3. Execute the commands (node v20-22 required)
 ```bash
 npm install
-npm start
+node bin/engine.mjs
 ```
+   Running the engine directly avoids npm's script banner lines so the NDJSON stream begins immediately.
 4.  Go to `localhost:8080` in your browser
 
 ## Running tests

--- a/test/engine-initial-output.test.mjs
+++ b/test/engine-initial-output.test.mjs
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'assert/strict';
+import { spawn } from 'child_process';
+import { once } from 'events';
+import { createInterface } from 'readline';
+import { fileURLToPath } from 'url';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+test('first stdout line is NDJSON', async () => {
+  const proc = spawn('node', ['bin/engine.mjs'], { cwd: ROOT });
+  const rl = createInterface({ input: proc.stdout });
+  const iter = rl[Symbol.asyncIterator]();
+  const { value: first } = await iter.next();
+  proc.kill();
+  await once(proc, 'exit');
+  assert.ok(first.startsWith('{'), `First line was: ${first}`);
+});

--- a/test/readme.md
+++ b/test/readme.md
@@ -3,6 +3,7 @@
 Automated checks for BarnLights Playbox:
 
 - `engine.test.mjs` – validates engine output and config section lengths.
+- `engine-initial-output.test.mjs` – verifies the first stdout line from the engine is NDJSON.
 - `engine-layout.test.mjs` – ensures layout loading rejects malformed files.
 - `config.test.mjs` – verifies configuration LED totals and section bounds.
 - `preset.test.mjs` – saves and loads effect presets and their preview images.


### PR DESCRIPTION
## Summary
- Remove npm start script to avoid banner output before NDJSON stream
- Document running the engine directly to start streaming clean data
- Add test verifying the first stdout line from the engine is NDJSON

## Testing
- `BARN_LIGHTS_SKIP_WEB_TEST=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aec5bd4d78832294b25f16caf89714