### PR TITLE
feat: improve UI loading and error states

### DIFF
--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -5,7 +5,7 @@ Browser interface providing a live preview above a panel of controls.
 
 - `index.html` – UI control layout and React mount point for the preview.
 - `main.mjs` – fetches layouts and exposes handlers used by the React app.
-- `App.jsx` – top-level React component that invokes `run` and provides context.
+- `App.jsx` – top-level React component that invokes `run`, delays the WebSocket connection until initialization completes, and displays status messages while loading or on errors.
 - `Renderer.jsx` – React component rendering preview canvases and driving the frame loop.
 - `main.jsx` – React entry rendering `<App />`.
 - `useWebSocket.js` – React hook for managing WebSocket connections.


### PR DESCRIPTION
## Summary
- show loading placeholder until layouts and scene are ready
- defer websocket connection until initialization to avoid reconnections
- surface fetch and websocket errors in root element

## Testing
- `npm test` *(fails: server not responding)*

------
https://chatgpt.com/codex/tasks/task_e_68af366c13548322994e24b746f9be12