### PR TITLE
Prevent runaway layout requests in UI

### DIFF
--- a/src/ui/ParamsContext.js
+++ b/src/ui/ParamsContext.js
@@ -38,10 +38,14 @@ export function ParamsProvider({ children, send, onReady }) {
 
   const applyLocal = useCallback((patchObject) => applyPatch(patchObject, false), [applyPatch]);
 
+  const readySendRef = useRef(null);
+
   useEffect(() => {
-    if (onReady) onReady({ dispatch: applyPatch, applyLocal, getParams: () => paramsRef.current });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onReady, applyPatch, applyLocal]);
+    if (onReady && readySendRef.current !== safeSend) {
+      readySendRef.current = safeSend;
+      onReady({ dispatch: applyPatch, applyLocal, getParams: () => paramsRef.current });
+    }
+  }, [onReady, applyPatch, applyLocal, safeSend]);
 
   return (
     <ParamsContext.Provider value={contextValue}>

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -10,7 +10,7 @@ Browser interface providing a live preview above a panel of controls.
 - `main.jsx` – React entry rendering `<App />`.
 - `useWebSocket.js` – React hook for managing WebSocket connections.
 - `WebSocketContext.js` – context provider exposing the connection to components.
-- `ParamsContext.js` – React context backed by a `useReducer` hook mirroring the runtime parameter object. Dispatching patches updates state and sends them over the WebSocket.
+- `ParamsContext.js` – React context backed by a `useReducer` hook mirroring the runtime parameter object. Dispatching patches updates state and sends them over the WebSocket. It invokes its `onReady` callback only when the WebSocket send function changes to avoid repeated initialization.
 - `renderer.mjs` – draws a single frame for both walls and overlays per‑LED indicators.
 - `presets.mjs` – handles saving/retreiving configuration and listing the saved options with thumbnails.
 - `subviews/` – reusable widgets and `renderControls` helper.


### PR DESCRIPTION
## Summary
- guard `ParamsContext` ready callback so it fires only when the WebSocket send function changes
- document callback behavior in UI README

## Testing
- `BARN_LIGHTS_SKIP_WEB_TEST=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af3a5ae2ec8322bfccca0583a1feb0