### PR TITLE
Add UI lifecycle logging for BarnLights

### DIFF
--- a/src/ui/App.js
+++ b/src/ui/App.js
@@ -19,6 +19,7 @@ export default function App({
   const [scene, setScene] = useState({ width: 0, height: 0 });
 
   const handleReady = useCallback((runtimeValue) => {
+    console.log('Runtime initialized');
     setRuntime(runtimeValue);
   }, []);
 
@@ -27,9 +28,16 @@ export default function App({
       runFunction(runtime.applyLocal, setScene).then(result => {
         setHandlers(result);
         setLayouts({ left: result.layoutLeft, right: result.layoutRight });
+        console.log('Layouts loaded');
       });
     }
   }, [runtime, runFunction]);
+
+  useEffect(() => {
+    if (runtime && layouts.left && layouts.right && scene.width && scene.height) {
+      console.log('CanvasPreview mounted');
+    }
+  }, [runtime, layouts.left, layouts.right, scene.width, scene.height]);
 
   const { onInit, onParams, onStatus } = handlers || {
     onInit: () => {},

--- a/src/ui/CanvasPreview.js
+++ b/src/ui/CanvasPreview.js
@@ -18,12 +18,14 @@ export default function CanvasPreview({
     const canvasLeft = canvasLeftRef.current;
     const canvasRight = canvasRightRef.current;
     if (!canvasLeft || !canvasRight) return;
+    console.log('CanvasPreview effect start');
 
     const contextLeft = canvasLeft.getContext('2d');
     const contextRight = canvasRight.getContext('2d');
     const leftFrame = new Float32Array(sceneWidth * sceneHeight * 3);
     const rightFrame = new Float32Array(sceneWidth * sceneHeight * 3);
     let frameRequest = 0;
+    let frameCounter = 0;
     const win = canvasLeft.ownerDocument.defaultView || window;
 
     const loop = () => {
@@ -39,6 +41,8 @@ export default function CanvasPreview({
         sceneWidth,
         sceneHeight
       );
+      console.log('CanvasPreview animation frame', frameCounter);
+      frameCounter += 1;
       if (shouldAnimate) {
         frameRequest = win.requestAnimationFrame(loop);
       }
@@ -50,6 +54,7 @@ export default function CanvasPreview({
     }
 
     return () => {
+      console.log('CanvasPreview cleanup');
       if (frameRequest && shouldAnimate) win.cancelAnimationFrame(frameRequest);
       clearImageCaches();
     };

--- a/src/ui/main.mjs
+++ b/src/ui/main.mjs
@@ -9,8 +9,13 @@ const layoutCache = {};
 
 async function loadLightLayout(win, doc, side){
   if (layoutCache[side]) return layoutCache[side];
+  console.log(`Fetching ${side} layout`);
   const promise = win.fetch(`/layout/${side}`)
-    .then(r => r.json())
+    .then(response => response.json())
+    .then(layout => {
+      console.log(`Fetched ${side} layout`);
+      return layout;
+    })
     .catch(err => {
       console.error(`Failed to load ${side} layout`, err);
       setStatus(doc, `Failed to load ${side} layout`);
@@ -39,6 +44,6 @@ export async function run(applyLocal, setSceneInfo, docArg = globalThis.document
   };
 
   const onStatus = (statusMessage) => setStatus(doc, statusMessage);
-
+  console.log('run resolved');
   return { onInit, onParams, onStatus, layoutLeft, layoutRight };
 }

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -20,3 +20,5 @@ Browser interface providing a live preview above a panel of controls.
 
 The UI is bundled with Webpack, treating this directory as the source and writing output to `dist/`.
 The generated `index.html` references the compiled bundle with `<script src="/bundle.js"></script>`.
+
+Console logging traces runtime initialization, layout loading, WebSocket activity, preview rendering, and cleanup to aid debugging.

--- a/src/ui/render-preview-frame.mjs
+++ b/src/ui/render-preview-frame.mjs
@@ -64,6 +64,7 @@ export function renderPreviewFrame(
   layoutLeft, layoutRight,
   sceneWidth, sceneHeight
 ) {
+  console.log('renderPreviewFrame start');
   const timeSeconds = browserWindow.performance.now() / 1000;
   const paramObject = getParams();
   renderFrames(leftFrame, rightFrame, paramObject, timeSeconds);
@@ -71,4 +72,5 @@ export function renderPreviewFrame(
   if (layoutLeft) drawSectionsToCanvas(contextLeft, leftFrame, layoutLeft, sceneWidth, sceneHeight);
   drawSceneToCanvas(contextRight, rightFrame, sceneWidth, sceneHeight, "right");
   if (layoutRight) drawSectionsToCanvas(contextRight, rightFrame, layoutRight, sceneWidth, sceneHeight);
+  console.log('renderPreviewFrame end');
 }

--- a/src/ui/useWebSocket.js
+++ b/src/ui/useWebSocket.js
@@ -14,6 +14,7 @@ export function useWebSocket(url, { onInit, onParams, onError } = {}) {
     let socket = null;
     const timer = setTimeout(() => {
       try {
+        console.log(`Attempting WebSocket connection to ${url}`);
         socket = new WebSocket(url);
         socketRef.current = socket;
         setReadyState('connecting');
@@ -25,16 +26,18 @@ export function useWebSocket(url, { onInit, onParams, onError } = {}) {
         };
 
         socket.onclose = (event) => {
-          console.warn('WebSocket closed', event);
+          console.log('WebSocket closed', event);
           setReadyState('closed');
           if (onError) onError('WebSocket connection closed');
         };
 
         socket.onopen = () => {
+          console.log('WebSocket opened');
           setReadyState('open');
         };
 
         socket.onmessage = (event) => {
+          console.log('WebSocket message received', event.data);
           const message = JSON.parse(event.data);
           if (message.type === 'init' && onInit) onInit(message);
           if (message.type === 'params' && onParams) onParams(message);
@@ -48,7 +51,10 @@ export function useWebSocket(url, { onInit, onParams, onError } = {}) {
 
     return () => {
       clearTimeout(timer);
-      if (socket) socket.close();
+      if (socket) {
+        console.log('Closing WebSocket connection');
+        socket.close();
+      }
     };
   }, [url, onInit, onParams, onError]);
 


### PR DESCRIPTION
## Summary
- add logging around layout fetches and runtime initialization
- instrument React app, WebSocket hook, and preview canvas with lifecycle logs
- note debugging logs in UI readme

## Testing
- `BARN_LIGHTS_SKIP_WEB_TEST=1 npm test` *(fails: Unknown file extension ".jsx" for ControlPanel.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68afabcd8bac83229d4c6ebd22a05698