### PR TITLE
Fix gradient picker bindings to sync with presets

### DIFF
--- a/src/ui/subviews/readme.md
+++ b/src/ui/subviews/readme.md
@@ -4,6 +4,6 @@ Dynamic UI widgets for effect parameters.
 
 - `index.js` – exports `EffectControls` and inline React widgets for numbers, checkboxes, buttons, enums, colors, and color stop editors.
 
-The `gradient` effect uses the `colorStops` widget to define its color palette.
+The `gradient` effect uses the `colorStops` widget to define its color palette. The widget keeps its Grapick picker in sync with parameter changes such as loading presets.
 
 Utilities for RGB conversions live in `utils.mjs`.


### PR DESCRIPTION
## Summary
- Keep Grapick gradient picker in sync with ColorStops parameter changes
- Document updated color stop widget behavior

## Testing
- `BARN_LIGHTS_SKIP_WEB_TEST=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b041940c2483229bd5b99f50ab561f