### PR TITLE
Add receiver reboot controls

### DIFF
--- a/src/readme.md
+++ b/src/readme.md
@@ -4,7 +4,7 @@ Core runtime code for BarnLights Playbox:
 
 - `render-scene.mjs` – shared scene rendering, post-processing and `renderFrames` helper for mapping scenes to both walls.
 - `engine.mjs` – side‑effect‑free render loop using `renderFrames` and exposing `params` (including `renderMode`); call `start()` to emit SLICES_NDJSON.
-- `server.mjs` – HTTP/WebSocket server serving the UI and applying param updates.
+- `server.mjs` – HTTP/WebSocket server serving the UI (including reboot controls) and applying param updates.
 - `config-store.mjs` – read/write helpers for saving only the active effect's preset and shared parameters; loading merges only values present in the preset JSON. Preview images are stored alongside presets. Saving with a duplicate name replaces the previous preset and its preview image.
 - `effects/` – effect implementations, registry and post-processing helpers.
 - `ui/` – browser UI for preview and controls, can modify the `params` which the engine renders.

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -29,6 +29,7 @@ const server = http.createServer(async (req, res) => {
   if (u.pathname === "/controls-logic.mjs") return streamFile(path.join(UI_DIR, "controls-logic.mjs"), "text/javascript", res);
   if (u.pathname === "/presets.mjs") return streamFile(path.join(UI_DIR, "presets.mjs"), "text/javascript", res);
   if (u.pathname === "/renderer.mjs") return streamFile(path.join(UI_DIR, "renderer.mjs"), "text/javascript", res);
+  if (u.pathname === "/reboot.mjs") return streamFile(path.join(UI_DIR, "reboot.mjs"), "text/javascript", res);
   if (u.pathname === "/render-scene.mjs") return streamFile(path.join(__dirname, "render-scene.mjs"), "text/javascript", res);
   if (u.pathname.startsWith("/subviews/")) {
     const p = path.join(UI_DIR, u.pathname.slice(1));

--- a/src/ui/controls-logic.mjs
+++ b/src/ui/controls-logic.mjs
@@ -4,6 +4,7 @@ import { renderControls } from './subviews/index.mjs';
 import { rgbToHex } from './subviews/utils.mjs';
 import { initSpeedSlider } from './subviews/speedSlider.mjs';
 import { refreshPresetPanel } from './presets.mjs';
+import { requestReboot } from './reboot.mjs';
 
 // Function used to send parameter patches back to the engine
 let sendFn = null;
@@ -186,6 +187,11 @@ export function initUI(win, doc, P, send){
     renderMode.value = P.renderMode;
     renderMode.onchange = () => { P.renderMode = renderMode.value; send({ renderMode: renderMode.value }); };
   }
+
+  const rebootLeft = doc.getElementById('rebootLeft');
+  if (rebootLeft) rebootLeft.onclick = () => requestReboot('left');
+  const rebootRight = doc.getElementById('rebootRight');
+  if (rebootRight) rebootRight.onclick = () => requestReboot('right');
   
   const updateAngles = () => {
     if (pitchDeg && doc.activeElement !== pitchDeg) pitchDeg.value = Math.abs(P.post.pitch || 0).toFixed(1);

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -71,10 +71,10 @@
       </div>
     </fieldset>
 
-    <fieldset>
-      <legend>Orientation</legend>
-      <div class="row">
-        <label>Pitch
+  <fieldset>
+    <legend>Orientation</legend>
+    <div class="row">
+      <label>Pitch
           <div id="pitch" class="hslider"><div class="handle"></div></div>
           <input id="pitchDeg" type="number" min="0" max="360" step="0.1" style="width:60px">
         </label>
@@ -82,8 +82,16 @@
           <div id="yaw" class="hslider"><div class="handle"></div></div>
           <input id="yawDeg" type="number" min="0" max="360" step="0.1" style="width:60px">
         </label>
-      </div>
-    </fieldset>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>Receivers</legend>
+    <div class="row">
+      <button id="rebootLeft">Reboot Left</button>
+      <button id="rebootRight">Reboot Right</button>
+    </div>
+  </fieldset>
 
   <fieldset>
     <legend>Strobe</legend>

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -8,5 +8,6 @@ Browser interface providing a live preview above a panel of controls.
 - `connection.mjs` – WebSocket setup and message handling.
 - `controls-logic.mjs` – wires DOM controls to params and renders effect-specific widgets.
 - `renderer.mjs` – uses `renderFrames` to draw the scene for both walls and overlay per-LED indicators.
+- `reboot.mjs` – issues reboot commands for individual receivers and repeats them every frame for a short duration.
 - `presets.mjs` – handles saving/retreiving configuration and listing the saved options with thumbnails.
 - `subviews/` – reusable widgets and `renderControls` helper.

--- a/src/ui/reboot.mjs
+++ b/src/ui/reboot.mjs
@@ -1,0 +1,16 @@
+import { send } from "./connection.mjs";
+
+const DURATION_MS = 500;
+const until = { left: 0, right: 0 };
+
+export function requestReboot(side){
+  const now = globalThis.performance.now();
+  until[side] = now + DURATION_MS;
+  send({ reboot: true, side });
+}
+
+export function tickReboot(now = globalThis.performance.now()){
+  if (until.left > now) send({ reboot: true, side: "left" });
+  if (until.right > now) send({ reboot: true, side: "right" });
+}
+

--- a/src/ui/renderer.mjs
+++ b/src/ui/renderer.mjs
@@ -1,5 +1,6 @@
 import { sliceSection, clamp01 } from "../effects/modifiers.mjs";
 import { renderFrames } from "../render-scene.mjs";
+import { tickReboot } from "./reboot.mjs";
 
 export function drawSceneToCanvas(ctx, sceneF32, sceneW, sceneH){
   const img = ctx.createImageData(sceneW, sceneH);
@@ -57,5 +58,6 @@ export function frame(
   if (layoutLeft) drawSectionsToCanvas(ctxL, leftFrame, layoutLeft, sceneW, sceneH);
   drawSceneToCanvas(ctxR, rightFrame, sceneW, sceneH);
   if (layoutRight) drawSectionsToCanvas(ctxR, rightFrame, layoutRight, sceneW, sceneH);
+  tickReboot(win.performance.now());
   win.requestAnimationFrame(() => frame(win, ctxL, ctxR, leftFrame, rightFrame, P, layoutLeft, layoutRight, sceneW, sceneH));
 }


### PR DESCRIPTION
## Summary
- add UI fieldset with left/right receiver reboot buttons
- wire buttons to send repeated reboot messages for 0.5s
- serve new reboot module and document the UI components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b68fc5c74c8322ab960090cf6b3fcc