### PR TITLE
feat(ui): flip preview canvases vertically

### DIFF
--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -14,8 +14,8 @@
   .desc { font-size:12px; color:#555; }
   .barn { display:flex; gap: 32px; perspective: 900px; margin:16px auto; justify-content:center; }
   canvas { width: 512px; height: 128px; image-rendering: pixelated; border-radius: 10px; box-shadow: 0 10px 30px rgba(0,0,0,.25); background:#000; }
-  #left { transform: rotateY(15deg) skewY(-2deg); }
-  #right{ transform: rotateY(-15deg) skewY(2deg);  }
+  #left { transform: scaleY(-1) rotateY(15deg) skewY(-2deg); }
+  #right{ transform: scaleY(-1) rotateY(-15deg) skewY(2deg);  }
   .panel { display:flex; flex-direction:row; gap:var(--gap); align-items:flex-start; flex-wrap:wrap; }
   .presetRow { display:flex; flex-direction:row; gap:10px; overflow-x:auto; }
   .presetItem { display:flex; flex-direction:column; align-items:center; cursor:pointer; }

--- a/src/ui/readme.md
+++ b/src/ui/readme.md
@@ -3,7 +3,7 @@
 Browser interface providing a live preview above a panel of controls.
 
 
-- `index.html` – UI control layout and visual effect preview. The "General" panel includes checkboxes to persist brightness, gamma, FPS cap and render mode when switching effects or presets.
+- `index.html` – UI control layout and visual effect preview. The "General" panel includes checkboxes to persist brightness, gamma, FPS cap and render mode when switching effects or presets. The preview canvases are flipped vertically to reflect the physical orientation of the LEDs.
 - `main.mjs` – entry point for JS logic, wiring modules together, exposes a 'run' function.
 - `connection.mjs` – WebSocket setup and message handling.
 - `controls-logic.mjs` – wires DOM controls to params and renders effect-specific widgets.


### PR DESCRIPTION
## Summary
- flip left and right preview canvases vertically in the UI so LEDs display in correct orientation
- document vertical flip in UI readme

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c47d207fe483228010304771905305